### PR TITLE
Update pydantic version and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,8 +368,8 @@ When `parse_dates=True` is specified, the API will attempt to convert any field 
 git clone <repository-url>
 cd flyrigloader
 
-# Install the package in development mode
-pip install -e .
+# Create the development environment
+./setup_env.sh --dev
 ```
 
 ### Testing

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   # Core Runtime Dependencies
   - python>=3.8,<3.12
   - loguru>=0.7.0
-  - pydantic>=2.0.0
+  - pydantic>=2.6
   - numpy>=1.21.0
   - pandas>=1.3.0
   

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.8"
 license = {text = "MIT"}
 dependencies = [
     "loguru>=0.7.0",
-    "pydantic>=2.0.0",
+    "pydantic>=2.6",
     "numpy>=1.21.0",
     "pandas>=1.3.0",
 ]

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEV=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --dev)
+      DEV=1
+      shift
+      ;;
+  esac
+done
+
+conda env create -n flyrigloader --file environment.yml
+
+if [[ $DEV -eq 1 ]]; then
+  conda run -n flyrigloader pip install -e .[dev]
+fi


### PR DESCRIPTION
## Summary
- pin `pydantic>=2.6` in both `environment.yml` and `pyproject.toml`
- add `setup_env.sh` script for creating a dev environment
- document running the new script in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684c44eb7ba48320a01246e27f0887ad