### PR TITLE
Ensure modules reference package logger

### DIFF
--- a/src/flyrigloader/api.py
+++ b/src/flyrigloader/api.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import copy
 from typing import Dict, List, Any, Optional, Union, Protocol, Callable
 from abc import ABC, abstractmethod
-from loguru import logger
+from flyrigloader import logger
 
 
 MISSING_DATA_DIR_ERROR = (

--- a/src/flyrigloader/discovery/__init__.py
+++ b/src/flyrigloader/discovery/__init__.py
@@ -23,7 +23,7 @@ Configurable Logging Context (Section 2.2.8):
 import os
 from typing import Any, Dict, List, Optional, Protocol, Union, runtime_checkable
 from pathlib import Path
-from loguru import logger
+from flyrigloader import logger
 
 # Core discovery functionality exports
 from flyrigloader.discovery.files import (

--- a/src/flyrigloader/discovery/files.py
+++ b/src/flyrigloader/discovery/files.py
@@ -11,7 +11,7 @@ from datetime import datetime
 import fnmatch
 from abc import ABC, abstractmethod
 
-from loguru import logger
+from flyrigloader import logger
 from flyrigloader.discovery.patterns import PatternMatcher, match_files_to_patterns
 from flyrigloader.discovery.stats import get_file_stats, attach_file_stats
 

--- a/src/flyrigloader/discovery/patterns.py
+++ b/src/flyrigloader/discovery/patterns.py
@@ -5,7 +5,7 @@ Utilities for working with regex patterns to extract metadata from filenames.
 """
 from typing import Any, Dict, List, Optional, Pattern, Union, Tuple, Protocol, Callable
 import re
-from loguru import logger
+from flyrigloader import logger
 from pathlib import Path
 from abc import ABC, abstractmethod
 

--- a/src/flyrigloader/io/column_models.py
+++ b/src/flyrigloader/io/column_models.py
@@ -81,7 +81,7 @@ class DefaultLogger:
     """Default logger implementation using Loguru."""
     
     def __init__(self):
-        from loguru import logger
+        from flyrigloader import logger
         self._logger = logger
     
     def debug(self, message: str) -> None:
@@ -754,7 +754,7 @@ def get_validation_diagnostics(dependencies: Optional[DependencyContainer] = Non
 
 # Import compatibility layer for backward compatibility
 try:
-    from loguru import logger
+    from flyrigloader import logger
     _legacy_logger = logger
 except ImportError:
     _legacy_logger = DefaultLogger()

--- a/src/flyrigloader/io/pickle.py
+++ b/src/flyrigloader/io/pickle.py
@@ -15,7 +15,7 @@ import pandas as pd
 from pathlib import Path
 from typing import Dict, Any, Union, Optional, List, Tuple, Protocol, runtime_checkable
 from abc import ABC, abstractmethod
-from loguru import logger
+from flyrigloader import logger
 from flyrigloader.io.column_models import (
     load_column_config, 
     ColumnConfigDict, 

--- a/src/flyrigloader/utils/__init__.py
+++ b/src/flyrigloader/utils/__init__.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Optional, Union, Callable, TypeVar
 
 # Enhanced error handling with logging support for test observability
 try:
-    from loguru import logger
+    from flyrigloader import logger
 except ImportError:
     # Fallback to standard logging for test environments without Loguru
     import logging

--- a/src/flyrigloader/utils/dataframe.py
+++ b/src/flyrigloader/utils/dataframe.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 
 import pandas as pd
-from loguru import logger
+from flyrigloader import logger
 
 from flyrigloader.discovery.stats import get_file_stats
 from flyrigloader.utils.paths import get_relative_path

--- a/src/flyrigloader/utils/paths.py
+++ b/src/flyrigloader/utils/paths.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 import os
 import sys
-from loguru import logger
+from flyrigloader import logger
 
 
 @runtime_checkable

--- a/tests/flyrigloader/test_logger_imports.py
+++ b/tests/flyrigloader/test_logger_imports.py
@@ -1,0 +1,35 @@
+"""Tests ensuring modules use the package level logger."""
+import importlib
+import flyrigloader
+
+class DummyLogger:
+    def debug(self, *a, **k):
+        pass
+    def info(self, *a, **k):
+        pass
+    def warning(self, *a, **k):
+        pass
+    def error(self, *a, **k):
+        pass
+    def configure(self, *a, **k):
+        pass
+
+def test_modules_reference_package_logger(monkeypatch):
+    dummy = DummyLogger()
+    monkeypatch.setattr(flyrigloader, "logger", dummy)
+
+    modules = [
+        flyrigloader.api,
+        flyrigloader.utils,
+        flyrigloader.utils.dataframe,
+        flyrigloader.utils.paths,
+        flyrigloader.discovery,
+        flyrigloader.discovery.files,
+        flyrigloader.discovery.patterns,
+        flyrigloader.io.pickle,
+        flyrigloader.io.column_models,
+    ]
+
+    for module in modules:
+        importlib.reload(module)
+        assert getattr(module, "logger") is dummy


### PR DESCRIPTION
## Summary
- add test ensuring each module reuses the package logger
- import logger from package root across modules

## Testing
- `pytest tests/flyrigloader/test_logger_imports.py::test_modules_reference_package_logger -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684c44ef322c8320a6de9df3cb169137