### PR TITLE
Ensure Pydantic BaseModel compatibility

### DIFF
--- a/src/flyrigloader/io/column_models.py
+++ b/src/flyrigloader/io/column_models.py
@@ -16,6 +16,9 @@ from typing import Dict, List, Optional, Union, Any, Literal, Callable, Protocol
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
+# Pydantic imports with v2 compatibility (F-020)
+from pydantic import BaseModel, Field, field_validator, model_validator
+
 import numpy as np
 import os
 

--- a/tests/flyrigloader/io/test_column_models.py
+++ b/tests/flyrigloader/io/test_column_models.py
@@ -11,13 +11,20 @@ from pydantic import ValidationError
 import pandas as pd
 
 from flyrigloader.io.column_models import (
-    ColumnConfig, 
-    ColumnConfigDict, 
-    ColumnDimension, 
+    ColumnConfig,
+    ColumnConfigDict,
+    ColumnDimension,
     SpecialHandlerType,
     load_column_config,
     get_config_from_source
 )
+import pydantic
+
+
+def test_models_inherit_basemodel():
+    """Ensure core models derive from Pydantic BaseModel."""
+    assert issubclass(ColumnConfig, pydantic.BaseModel)
+    assert issubclass(ColumnConfigDict, pydantic.BaseModel)
 from flyrigloader.io.pickle import make_dataframe_from_config
 
 


### PR DESCRIPTION
## Summary
- import Pydantic BaseModel utilities with v2 compatibility
- check that ColumnConfig and ColumnConfigDict inherit from BaseModel

## Testing
- `pytest tests/flyrigloader/io/test_column_models.py::test_models_inherit_basemodel -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_684c468949e88320ae30919db405ff90