### PR TITLE
Add ensure_directory utility

### DIFF
--- a/src/flyrigloader/utils/__init__.py
+++ b/src/flyrigloader/utils/__init__.py
@@ -165,7 +165,8 @@ try:
         get_relative_path as _get_relative_path,
         get_absolute_path as _get_absolute_path,
         find_common_base_directory as _find_common_base_directory,
-        ensure_directory_exists as _ensure_directory_exists
+        ensure_directory_exists as _ensure_directory_exists,
+        ensure_directory as _ensure_directory
     )
     logger.debug("Successfully imported path utilities")
 except ImportError as e:
@@ -232,6 +233,12 @@ def ensure_directory_exists(*args, **kwargs):
     func = _import_with_test_hooks('paths', 'ensure_directory_exists', _ensure_directory_exists)
     return func(*args, **kwargs)
 
+
+def ensure_directory(*args, **kwargs):
+    """Ensure a directory exists using the public utility with test hook support."""
+    func = _import_with_test_hooks('paths', 'ensure_directory', _ensure_directory)
+    return func(*args, **kwargs)
+
 def build_manifest_df(*args, **kwargs):
     """
     Convert discovery results to a pandas DataFrame with test hook support.
@@ -283,6 +290,7 @@ _base_exports = [
     'get_absolute_path',
     'find_common_base_directory',
     'ensure_directory_exists',
+    'ensure_directory',
     
     # DataFrame utilities
     'build_manifest_df',

--- a/src/flyrigloader/utils/paths.py
+++ b/src/flyrigloader/utils/paths.py
@@ -418,6 +418,41 @@ def ensure_directory_exists(
         raise ValueError(f"Failed to ensure directory exists at {path}: {e}") from e
 
 
+def ensure_directory(directory: Path, exist_ok: bool = True) -> None:
+    """Ensure a directory exists, creating it if necessary.
+
+    Args:
+        directory (Path): The directory path to create if missing.
+        exist_ok (bool, optional): If ``True`` (default), no exception is raised
+            when the directory already exists.
+
+    Raises:
+        PermissionError: If there are insufficient permissions to create the
+            directory.
+        FileExistsError: If ``exist_ok`` is ``False`` and the directory already
+            exists.
+        OSError: For other filesystem-related errors.
+
+    Example:
+        >>> from pathlib import Path
+        >>> ensure_directory(Path('output'))
+    """
+
+    try:
+        dir_path = Path(directory)
+        dir_path.mkdir(parents=True, exist_ok=exist_ok)
+        logger.debug(f"Directory ensured: {dir_path} (exist_ok={exist_ok})")
+    except PermissionError as e:
+        logger.error(f"Permission denied creating directory {dir_path}: {e}")
+        raise
+    except FileExistsError as e:
+        logger.error(f"Directory already exists at {dir_path}: {e}")
+        raise
+    except OSError as e:
+        logger.error(f"Error creating directory {dir_path}: {e}")
+        raise
+
+
 def check_file_exists(
     file_path: Union[str, Path],
     *,


### PR DESCRIPTION
## Summary
- add `ensure_directory` public utility to `utils.paths`
- expose new utility from `utils` package
- test directory creation scenarios

## Testing
- `pytest tests/flyrigloader/utils/test_paths.py::TestEnsureDirectory::test_ensure_directory_existing_no_error -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850a418cd008320bbf5f80d9dfc4253