### PR TITLE
Fix discovery provider import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "flyrigloader"
-version = "0.1.0"
+version = "0.1.1"
 description = "Tools for managing and controlling fly rigs for neuroscience experiments"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/flyrigloader/__init__.py
+++ b/src/flyrigloader/__init__.py
@@ -2,7 +2,7 @@
 FlyRigLoader - Tools for managing and controlling fly rigs for neuroscience experiments.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 import sys
 import os

--- a/src/flyrigloader/api.py
+++ b/src/flyrigloader/api.py
@@ -178,16 +178,13 @@ class DefaultDependencyProvider:
         """Get discovery provider with lazy loading."""
         if self._discovery_module is None:
             logger.debug("Loading discovery module dependencies")
-            from flyrigloader.config.discovery import (
-                discover_files_with_config,
-                discover_experiment_files,
-                discover_dataset_files
-            )
-            
+            import importlib
+            discovery_mod = importlib.import_module("flyrigloader.config.discovery")
+
             class DiscoveryModule:
-                discover_files_with_config = staticmethod(discover_files_with_config)
-                discover_experiment_files = staticmethod(discover_experiment_files)
-                discover_dataset_files = staticmethod(discover_dataset_files)
+                discover_files_with_config = staticmethod(discovery_mod.discover_files_with_config)
+                discover_experiment_files = staticmethod(discovery_mod.discover_experiment_files)
+                discover_dataset_files = staticmethod(discovery_mod.discover_dataset_files)
             
             self._discovery_module = DiscoveryModule()
         return self._discovery_module


### PR DESCRIPTION
## Summary
- fix API discovery provider import to use importlib
- bump version to 0.1.1

## Testing
- `pytest -q` *(fails: No module named 'hypothesis')*

------
https://chatgpt.com/codex/tasks/task_e_6851b722ba108320aabed2d571ac0618