### PR TITLE
fix: normalize manifest metadata defaults

### DIFF
--- a/src/flyrigloader/api.py
+++ b/src/flyrigloader/api.py
@@ -814,7 +814,7 @@ def discover_experiment_manifest(
             manifest_dict[file_info.path] = {
                 'path': file_info.path,
                 'size': file_info.size or 0,
-                'metadata': file_info.extracted_metadata,
+                'metadata': file_info.extracted_metadata if file_info.extracted_metadata is not None else {},
                 'parsed_dates': {'parsed_date': file_info.parsed_date} if file_info.parsed_date else {}
             }
         

--- a/tests/test_manifest_metadata_defaults.py
+++ b/tests/test_manifest_metadata_defaults.py
@@ -1,0 +1,31 @@
+import flyrigloader.api as api
+from flyrigloader.api import discover_experiment_manifest
+from flyrigloader.discovery.files import FileManifest, FileInfo
+
+
+def test_manifest_metadata_defaults_to_empty_dict(monkeypatch):
+    """Ensure manifest conversion normalizes missing metadata to empty dict."""
+    captured_calls = {}
+
+    def fake_discover(**kwargs):
+        captured_calls.update(kwargs)
+        return FileManifest(
+            files=[
+                FileInfo(path='/data/file.pkl', size=None, extracted_metadata=None, parsed_date=None)
+            ]
+        )
+
+    monkeypatch.setattr(api, '_discover_experiment_manifest', fake_discover)
+
+    config = {
+        'project': {'directories': {'major_data_directory': '/data'}},
+        'experiments': {'exp': {'datasets': ['dataset']}}
+    }
+
+    manifest = discover_experiment_manifest(config=config, experiment_name='exp')
+
+    assert manifest['/data/file.pkl']['metadata'] == {}
+    assert manifest['/data/file.pkl']['size'] == 0
+    assert manifest['/data/file.pkl']['parsed_dates'] == {}
+    assert captured_calls['parse_dates'] is True
+    assert captured_calls['include_stats'] is True


### PR DESCRIPTION
## Summary
- ensure `discover_experiment_manifest` normalizes missing metadata entries to empty dictionaries
- add a regression test covering metadata defaults and argument propagation

## Testing
- pytest tests/test_manifest_metadata_defaults.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cd99915f048320a7b0bb7ed9c1d6c9