### PR TITLE
Surface discovered file stats in manifest outputs

### DIFF
--- a/src/flyrigloader/api.py
+++ b/src/flyrigloader/api.py
@@ -856,12 +856,21 @@ def discover_experiment_manifest(
             else:
                 metadata_payload = {}
 
-            manifest_dict[file_info.path] = {
+            manifest_entry: Dict[str, Any] = {
                 'path': file_info.path,
                 'size': file_info.size if file_info.size is not None else 0,
                 'metadata': metadata_payload,
                 'parsed_dates': {'parsed_date': file_info.parsed_date} if file_info.parsed_date else {}
             }
+
+            if file_info.mtime is not None:
+                manifest_entry['mtime'] = file_info.mtime
+            if file_info.ctime is not None:
+                manifest_entry['ctime'] = file_info.ctime
+            if file_info.creation_time is not None:
+                manifest_entry['creation_time'] = file_info.creation_time
+
+            manifest_dict[file_info.path] = manifest_entry
         
         file_count = len(manifest_dict)
         total_size = sum(item.get('size', 0) for item in manifest_dict.values())

--- a/src/flyrigloader/api.py
+++ b/src/flyrigloader/api.py
@@ -850,10 +850,16 @@ def discover_experiment_manifest(
         # Convert FileManifest to dictionary format for backward compatibility
         manifest_dict = {}
         for file_info in file_manifest.files:
+            metadata_payload: Dict[str, Any]
+            if isinstance(file_info.extracted_metadata, dict):
+                metadata_payload = dict(file_info.extracted_metadata)
+            else:
+                metadata_payload = {}
+
             manifest_dict[file_info.path] = {
                 'path': file_info.path,
-                'size': file_info.size or 0,
-                'metadata': file_info.extracted_metadata if file_info.extracted_metadata is not None else {},
+                'size': file_info.size if file_info.size is not None else 0,
+                'metadata': metadata_payload,
                 'parsed_dates': {'parsed_date': file_info.parsed_date} if file_info.parsed_date else {}
             }
         

--- a/tests/test_manifest_metadata_defaults.py
+++ b/tests/test_manifest_metadata_defaults.py
@@ -24,9 +24,14 @@ def test_manifest_metadata_defaults_to_empty_dict(monkeypatch):
 
     manifest = discover_experiment_manifest(config=config, experiment_name='exp')
 
-    assert manifest['/data/file.pkl']['metadata'] == {}
-    assert manifest['/data/file.pkl']['size'] == 0
-    assert manifest['/data/file.pkl']['parsed_dates'] == {}
+    entry = manifest['/data/file.pkl']
+
+    assert entry['metadata'] == {}
+    assert entry['size'] == 0
+    assert entry['parsed_dates'] == {}
+    assert 'mtime' not in entry
+    assert 'ctime' not in entry
+    assert 'creation_time' not in entry
     assert captured_calls['parse_dates'] is True
     assert captured_calls['include_stats'] is True
 
@@ -58,3 +63,6 @@ def test_manifest_stats_payload_sets_size(monkeypatch):
     entry = manifest['/data/file.pkl']
     assert entry['size'] == 1234
     assert entry['metadata'] == {'custom': 'value'}
+    assert entry['mtime'] == 456.0
+    assert entry['ctime'] == 789.0
+    assert entry['creation_time'] == 321.0

--- a/tests/test_manifest_metadata_defaults.py
+++ b/tests/test_manifest_metadata_defaults.py
@@ -1,6 +1,6 @@
 import flyrigloader.api as api
 from flyrigloader.api import discover_experiment_manifest
-from flyrigloader.discovery.files import FileManifest, FileInfo
+from flyrigloader.discovery.files import FileManifest, FileInfo, FileDiscoverer
 
 
 def test_manifest_metadata_defaults_to_empty_dict(monkeypatch):
@@ -29,3 +29,32 @@ def test_manifest_metadata_defaults_to_empty_dict(monkeypatch):
     assert manifest['/data/file.pkl']['parsed_dates'] == {}
     assert captured_calls['parse_dates'] is True
     assert captured_calls['include_stats'] is True
+
+
+def test_manifest_stats_payload_sets_size(monkeypatch):
+    """Stats metadata should populate size and be removed from metadata payload."""
+
+    def fake_discover(**kwargs):
+        discoverer = FileDiscoverer()
+        stats_metadata = {
+            'size': 1234,
+            'mtime': 456.0,
+            'ctime': 789.0,
+            'creation_time': 321.0,
+            'custom': 'value'
+        }
+        file_info = discoverer.create_version_aware_file_info('/data/file.pkl', stats_metadata)
+        return FileManifest(files=[file_info])
+
+    monkeypatch.setattr(api, '_discover_experiment_manifest', fake_discover)
+
+    config = {
+        'project': {'directories': {'major_data_directory': '/data'}},
+        'experiments': {'exp': {'datasets': ['dataset']}}
+    }
+
+    manifest = discover_experiment_manifest(config=config, experiment_name='exp')
+
+    entry = manifest['/data/file.pkl']
+    assert entry['size'] == 1234
+    assert entry['metadata'] == {'custom': 'value'}


### PR DESCRIPTION
## Summary
- ensure `FileDiscoverer.create_version_aware_file_info` promotes stat fields onto `FileInfo`
- rely on populated stat attributes when converting manifests in the public API
- extend manifest metadata tests to assert stats-provided sizes surface correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d30cbed970832097c2a3620b24b852