### PR TITLE
feat: add configurable path security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,17 @@ The latest version includes a comprehensive refactoring that enhances modularity
 
 - **Console logging**: INFO-level logs with colored output for better readability
 - **File logging**: DEBUG-level logs with automatic file rotation
-- **Automatic setup**: Log directory is created automatically on import
+- **Explicit initialization**: Call `initialize_logger()` to configure sinks and create directories
 - **Structured output**: Includes timestamps, log levels, file/function info
 
 Example usage:
 
 ```python
+from flyrigloader import initialize_logger
 from loguru import logger
+
+# Initialize logging explicitly (creates directories if needed)
+initialize_logger()
 
 # These will go to both console and log file
 logger.info("Processing experiment data")

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -50,6 +50,10 @@ class ProjectConfig(BaseModel):
         default_factory=dict,
         description="Dictionary of directory paths including major_data_directory"
     )
+    path_security: Optional[PathSecurityConfig] = Field(
+        default=None,
+        description="Overrides for directory traversal protection"
+    )
     ignore_substrings: Optional[List[str]] = Field(
         default=None,
         description="List of substring patterns to ignore during file discovery"
@@ -65,7 +69,7 @@ class ProjectConfig(BaseModel):
 ```
 
 **Key Features:**
-- **Directory validation**: Automatically checks path existence and security
+- **Directory validation**: Automatically checks path existence and security with configurable sensitive-root policies
 - **Pattern compilation**: Validates regex patterns at load time to prevent runtime errors
 - **Flexible structure**: Supports additional fields for future extensibility
 
@@ -778,3 +782,18 @@ configuration_health_check("config.yaml")
 This configuration guide provides comprehensive documentation for the new Pydantic-based configuration system in FlyRigLoader. The system offers powerful validation, type safety, and enhanced developer experience while maintaining full backward compatibility with existing configurations.
 
 For additional support or feature requests, please refer to the project documentation or open an issue in the repository.
+### PathSecurityConfig
+
+`PathSecurityConfig` allows projects to tailor which filesystem roots are treated
+as sensitive. When provided on `ProjectConfig`, the generated policy is supplied
+to the directory validator so that explicitly allowed locations (for example,
+`/var/lib`) are accepted while traversal patterns continue to be rejected.
+
+```python
+class PathSecurityConfig(BaseModel):
+    allowed_roots: Optional[List[str]] = Field(default=None)
+    sensitive_roots: Optional[List[str]] = Field(default=None)
+```
+
+If `allowed_roots` is set, the entries augment the defaults supplied by the
+validator module. Providing `sensitive_roots` replaces the default deny list.

--- a/docs/reports/path_validation_audit.md
+++ b/docs/reports/path_validation_audit.md
@@ -1,0 +1,43 @@
+# Path Validation Audit
+
+Date: 2025-09-24
+
+This note captures the current consumers of the path traversal safeguards and
+highlights the surface area affected by the restrictive defaults.
+
+## Key Components
+
+- `path_traversal_protection`: the core validator that enforces traversal
+  checks, URL blocking, and sensitive-root restrictions.
+- `path_existence_validator`: wraps the traversal checks with optional
+  filesystem existence validation and the pytest-aware bypass.
+- `ProjectConfig` directory validation: the only configuration model that
+  invokes `path_existence_validator`, thereby inheriting the sensitive-root
+  blacklist.
+
+## Call Sites
+
+| Location | Purpose | Notes |
+| --- | --- | --- |
+| `src/flyrigloader/config/models.py` (`ProjectConfig.apply_directory_security`) | Validates every configured directory on model construction | Blocks `/etc`, `/var`, `/dev`, `/proc`, `/sys`, `/root`, `/bin`, `/sbin` by default. |
+| `src/flyrigloader/config/validators.py` (`path_existence_validator`) | Exported for direct use by other modules and extensions | Currently not consumed elsewhere in the repository, but part of the public API referenced by docs. |
+
+## Observations
+
+1. The sensitive-root guard is effectively global because `ProjectConfig`
+   instantiates it for every directory field. No other configuration model
+   overrides the behaviour.
+2. Legitimate deployments under `/var` or `/etc` fail even in tests because the
+   blacklist is evaluated before filesystem checks.
+3. Third-party extensions that import `path_existence_validator` inherit the
+   same hard-coded restrictions with no configuration hook.
+
+## Recommended Adjustments
+
+- Introduce a configuration-backed policy so that projects can explicitly allow
+  certain roots without disabling traversal detection.
+- Ensure logging clearly indicates when policy overrides allow a path that
+  would otherwise be blocked.
+- Document the manual nature of logger initialization to avoid confusion during
+  policy debugging (log directories are only created when
+  `initialize_logger()` runs).

--- a/tests/flyrigloader/config/test_path_security_config.py
+++ b/tests/flyrigloader/config/test_path_security_config.py
@@ -1,0 +1,35 @@
+"""Targeted tests for configurable path security policies."""
+
+import pytest
+
+from flyrigloader.config.models import PathSecurityConfig, ProjectConfig
+from flyrigloader.config.validators import PathSecurityPolicy
+
+
+def test_project_config_allows_sensitive_root_with_policy() -> None:
+    """Explicitly allowing /var should permit those directories."""
+    config = ProjectConfig(
+        directories={"major_data_directory": "/var/lib/service"},
+        path_security=PathSecurityConfig(allowed_roots=["/var"]),
+    )
+
+    assert config.directories == {"major_data_directory": "/var/lib/service"}
+
+
+def test_project_config_rejects_invalid_path_security_entries() -> None:
+    """Non-absolute allow lists should fail fast with actionable errors."""
+    with pytest.raises(ValueError, match="Invalid path_security configuration"):
+        ProjectConfig(
+            directories={"major_data_directory": "/var/lib/service"},
+            path_security=PathSecurityConfig(allowed_roots=["relative/path"]),
+        )
+
+
+def test_path_security_config_merges_with_base_policy() -> None:
+    """Custom allow lists extend base policy roots without duplication."""
+    base_policy = PathSecurityPolicy(allowed_roots=("/tmp",))
+    config = PathSecurityConfig(allowed_roots=["/var"])
+
+    merged_policy = config.to_policy(base_policy)
+
+    assert set(merged_policy.allowed_roots) == {"/tmp", "/var"}

--- a/tests/flyrigloader/test_validators_paths.py
+++ b/tests/flyrigloader/test_validators_paths.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from flyrigloader.config.validators import path_existence_validator
+from flyrigloader.config.validators import (
+    PathSecurityPolicy,
+    path_existence_validator,
+)
 
 
 def test_path_existence_validator_rejects_sensitive_root() -> None:
@@ -16,3 +19,18 @@ def test_path_existence_validator_rejects_sensitive_root() -> None:
 def test_path_existence_validator_allows_usr_local_subdirectory() -> None:
     """System subdirectories like /usr/local should pass validation."""
     assert path_existence_validator("/usr/local/testdata") is True
+
+
+def test_path_existence_validator_respects_allowed_roots_policy() -> None:
+    """Legitimate usage under /var succeeds when explicitly allowed."""
+    policy = PathSecurityPolicy(allowed_roots=("/var",))
+
+    assert path_existence_validator("/var/lib/service", policy=policy) is True
+
+
+def test_path_existence_validator_still_blocks_traversal_attempts() -> None:
+    """Traversal patterns remain blocked even when root is allowed."""
+    policy = PathSecurityPolicy(allowed_roots=("/var",))
+
+    with pytest.raises(ValueError, match="Path traversal is not allowed"):
+        path_existence_validator("/var/lib/../../etc/passwd", policy=policy)


### PR DESCRIPTION
## Summary
- introduce a reusable PathSecurityPolicy with configurable allow/deny roots and update validators to honor it
- extend ProjectConfig with a PathSecurityConfig helper so directory validation can opt into relaxed policies
- add docs covering the audit, new configuration options, and clarify that logging requires explicit initialization

## Testing
- `pytest tests/flyrigloader/test_validators_paths.py tests/flyrigloader/config/test_path_security_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3fea1ded0832091894c470f046051