### PR TITLE
refactor: split api submodules

### DIFF
--- a/src/flyrigloader/api/__init__.py
+++ b/src/flyrigloader/api/__init__.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any, Dict
+
 from flyrigloader.exceptions import FlyRigLoaderError
 
 from .config import (
@@ -31,68 +34,73 @@ from .dependencies import (
 from .kedro import FlyRigLoaderDataSet, check_kedro_available, create_kedro_dataset
 from .manifest import discover_experiment_manifest, validate_manifest
 from .registry import get_loader_capabilities, get_registered_loaders
-from ._core import (
-    _create_test_dependency_provider,
-    _discover_experiment_manifest,
-    _load_data_file,
-    _transform_to_dataframe,
-    deprecated,
-    get_dataset_parameters,
-    get_experiment_parameters,
-    load_data_file,
-    load_dataset_files,
-    load_experiment_files,
-    process_experiment_data,
-    transform_to_dataframe,
-)
 from flyrigloader.config.models import create_config
 from flyrigloader.io.column_models import get_config_from_source
 from flyrigloader.io.pickle import read_pickle_any_format
 from flyrigloader.io.transformers import make_dataframe_from_config
 
-__all__ = [
-    "CONFIG_SOURCE_ERROR_MESSAGE",
-    "MISSING_DATA_DIR_ERROR",
-    "DefaultDependencyProvider",
-    "FlyRigLoaderDataSet",
-    "FlyRigLoaderError",
-    "_attach_metadata_bucket",
-    "_coerce_config_for_version_validation",
-    "_create_test_dependency_provider",
-    "_discover_experiment_manifest",
-    "_load_and_validate_config",
-    "_load_data_file",
-    "_raise_path_validation_error",
-    "_resolve_base_directory",
-    "_resolve_config_source",
-    "_validate_config_parameters",
-    "_transform_to_dataframe",
-    "check_if_file_exists",
-    "check_kedro_available",
-    "create_config",
-    "create_kedro_dataset",
-    "deprecated",
-    "discover_experiment_manifest",
-    "ensure_dir_exists",
-    "get_common_base_dir",
-    "get_config_from_source",
-    "get_dataset_parameters",
-    "get_default_column_config",
-    "get_dependency_provider",
-    "get_experiment_parameters",
-    "get_file_statistics",
-    "get_loader_capabilities",
-    "get_path_absolute",
-    "get_path_relative_to",
-    "get_registered_loaders",
-    "load_data_file",
-    "load_dataset_files",
-    "load_experiment_files",
-    "make_dataframe_from_config",
-    "process_experiment_data",
-    "read_pickle_any_format",
-    "reset_dependency_provider",
-    "set_dependency_provider",
-    "transform_to_dataframe",
-    "validate_manifest",
-]
+_CORE_EXPORTS: Dict[str, str] = {
+    "_create_test_dependency_provider": "_create_test_dependency_provider",
+    "_discover_experiment_manifest": "_discover_experiment_manifest",
+    "_load_data_file": "_load_data_file",
+    "_transform_to_dataframe": "_transform_to_dataframe",
+    "deprecated": "deprecated",
+    "get_dataset_parameters": "get_dataset_parameters",
+    "get_experiment_parameters": "get_experiment_parameters",
+    "load_data_file": "load_data_file",
+    "load_dataset_files": "load_dataset_files",
+    "load_experiment_files": "load_experiment_files",
+    "process_experiment_data": "process_experiment_data",
+    "transform_to_dataframe": "transform_to_dataframe",
+}
+
+__all__ = sorted(
+    {
+        "CONFIG_SOURCE_ERROR_MESSAGE",
+        "MISSING_DATA_DIR_ERROR",
+        "DefaultDependencyProvider",
+        "FlyRigLoaderDataSet",
+        "FlyRigLoaderError",
+        "_attach_metadata_bucket",
+        "_coerce_config_for_version_validation",
+        "_load_and_validate_config",
+        "_raise_path_validation_error",
+        "_resolve_base_directory",
+        "_resolve_config_source",
+        "_validate_config_parameters",
+        "check_if_file_exists",
+        "check_kedro_available",
+        "create_config",
+        "create_kedro_dataset",
+        "discover_experiment_manifest",
+        "ensure_dir_exists",
+        "get_common_base_dir",
+        "get_config_from_source",
+        "get_default_column_config",
+        "get_dependency_provider",
+        "get_file_statistics",
+        "get_loader_capabilities",
+        "get_path_absolute",
+        "get_path_relative_to",
+        "get_registered_loaders",
+        "make_dataframe_from_config",
+        "read_pickle_any_format",
+        "reset_dependency_provider",
+        "set_dependency_provider",
+        "validate_manifest",
+        *_CORE_EXPORTS.keys(),
+    }
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _CORE_EXPORTS:
+        module = import_module("flyrigloader.api._core")
+        value = getattr(module, _CORE_EXPORTS[name])
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module 'flyrigloader.api' has no attribute '{name}'")
+
+
+def __dir__() -> list[str]:
+    return sorted(list(globals().keys()) + list(_CORE_EXPORTS.keys()))

--- a/src/flyrigloader/api/_shared.py
+++ b/src/flyrigloader/api/_shared.py
@@ -1,0 +1,28 @@
+"""Shared helpers for :mod:`flyrigloader.api` submodules."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any, Callable
+
+
+def resolve_api_override(
+    target_globals: dict[str, Any],
+    name: str,
+    fallback: Callable[..., Any] | Any,
+) -> Callable[..., Any] | Any:
+    """Return patched attribute from :mod:`flyrigloader.api` when available."""
+
+    try:
+        api_module = importlib.import_module("flyrigloader.api")
+    except Exception:
+        target_globals[name] = fallback
+        return fallback
+
+    override = getattr(api_module, name, fallback)
+    target_globals[name] = override
+    return override
+
+
+__all__ = ["resolve_api_override"]
+

--- a/src/flyrigloader/api/config.py
+++ b/src/flyrigloader/api/config.py
@@ -2,24 +2,592 @@
 
 from __future__ import annotations
 
-from ._core import (
-    CONFIG_SOURCE_ERROR_MESSAGE,
-    MISSING_DATA_DIR_ERROR,
-    _attach_metadata_bucket,
-    _coerce_config_for_version_validation,
-    _load_and_validate_config,
-    _raise_path_validation_error,
-    _resolve_base_directory,
-    _resolve_config_source,
-    _validate_config_parameters,
-    check_if_file_exists,
-    ensure_dir_exists,
-    get_common_base_dir,
-    get_default_column_config,
-    get_file_statistics,
-    get_path_absolute,
-    get_path_relative_to,
+import copy
+import os
+from collections.abc import MutableMapping
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+from semantic_version import Version
+
+from flyrigloader import logger
+from flyrigloader.config.models import LegacyConfigAdapter
+from flyrigloader.config.validators import validate_config_version
+from flyrigloader.config.versioning import CURRENT_SCHEMA_VERSION
+from flyrigloader.exceptions import FlyRigLoaderError
+from flyrigloader.io.column_models import ColumnConfigDict
+
+from .dependencies import DefaultDependencyProvider, get_dependency_provider
+
+
+MISSING_DATA_DIR_ERROR = (
+    "No data directory specified. Either provide base_directory parameter "
+    "or ensure 'major_data_directory' is set in config."
 )
+
+CONFIG_SOURCE_ERROR_MESSAGE = "Exactly one of 'config_path' or 'config' must be provided"
+
+
+def _validate_config_parameters(
+    config_path: Optional[Union[str, Path]],
+    config: Optional[Dict[str, Any]],
+    operation_name: str,
+) -> None:
+    """Ensure callers provide exactly one configuration source."""
+
+    logger.debug(f"Validating config parameters for {operation_name}")
+
+    both_missing = config_path is None and config is None
+    both_provided = config_path is not None and config is not None
+
+    if both_missing or both_provided:
+        if both_missing:
+            logger.error(
+                f"Configuration source validation failed for {operation_name}: neither config nor config_path was provided"
+            )
+        else:
+            logger.error(
+                f"Configuration source validation failed for {operation_name}: both config and config_path were provided"
+            )
+        raise ValueError(CONFIG_SOURCE_ERROR_MESSAGE)
+
+    logger.debug(f"Config parameter validation successful for {operation_name}")
+
+
+def _load_and_validate_config(
+    config_path: Optional[Union[str, Path]],
+    config: Optional[Union[Dict[str, Any], Any]],
+    operation_name: str,
+    deps: Optional[DefaultDependencyProvider] = None,
+) -> Dict[str, Any]:
+    """Load and validate configuration with enhanced error handling."""
+
+    if deps is None:
+        deps = get_dependency_provider()
+
+    logger.debug(f"Loading and validating config for {operation_name}")
+
+    if config_path is not None:
+        try:
+            logger.info(f"Loading configuration from file: {config_path}")
+            config_dict = deps.config.load_config(config_path)
+            logger.debug(f"Successfully loaded config from {config_path}")
+        except FileNotFoundError as exc:
+            error_msg = (
+                f"Configuration file not found for {operation_name}: {config_path}. "
+                "Please ensure the file exists and the path is correct."
+            )
+            logger.error(error_msg)
+            raise FlyRigLoaderError(error_msg) from exc
+        except Exception as exc:
+            error_msg = (
+                f"Failed to load configuration for {operation_name} from {config_path}: {exc}. "
+                "Please check the file format and syntax."
+            )
+            logger.error(error_msg)
+            raise FlyRigLoaderError(error_msg) from exc
+    else:
+        logger.debug(f"Using pre-loaded configuration for {operation_name}")
+        config_dict = copy.deepcopy(config)
+
+    if hasattr(config_dict, "keys") and hasattr(config_dict, "__getitem__") and hasattr(config_dict, "get"):
+        logger.debug(f"Configuration is dict-like for {operation_name}")
+
+        if not isinstance(config_dict, dict):
+            try:
+                dict_config: Dict[str, Any] = {}
+                for key in config_dict.keys():
+                    dict_config[key] = config_dict[key]
+                config_dict = dict_config
+                logger.debug(f"Converted LegacyConfigAdapter to dictionary for {operation_name}")
+            except Exception as exc:
+                error_msg = (
+                    f"Failed to convert configuration to dictionary for {operation_name}: {exc}. "
+                    "Configuration must be convertible to dictionary structure."
+                )
+                logger.error(error_msg)
+                raise FlyRigLoaderError(error_msg) from exc
+    elif not isinstance(config_dict, dict):
+        error_msg = (
+            f"Invalid configuration format for {operation_name}: "
+            f"Expected dictionary or dict-like object, got {type(config_dict).__name__}. "
+            "Configuration must be a valid dictionary structure or LegacyConfigAdapter."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    logger.debug(f"Configuration validation successful for {operation_name}")
+    return config_dict
+
+
+def _resolve_config_source(
+    config: Optional[Union[Dict[str, Any], Any]],
+    config_path: Optional[Union[str, Path]],
+    operation_name: str,
+    deps: Optional[DefaultDependencyProvider],
+) -> Dict[str, Any]:
+    """Return the concrete configuration dictionary for the requested operation."""
+
+    _validate_config_parameters(config_path, config, operation_name)
+
+    if config is not None:
+        logger.debug(f"Using provided configuration object for {operation_name}")
+        return config  # type: ignore[return-value]
+
+    assert config_path is not None
+    logger.debug(f"Loading configuration from file source {config_path} for {operation_name}")
+    return _load_and_validate_config(config_path, None, operation_name, deps)
+
+
+def _coerce_config_for_version_validation(config_obj: Any) -> Union[Dict[str, Any], str]:
+    """Normalize configuration objects before schema version validation."""
+
+    if isinstance(config_obj, (dict, str)):
+        return config_obj
+
+    if isinstance(config_obj, MutableMapping):
+        logger.debug(
+            f"Converted MutableMapping configuration of type {type(config_obj).__name__} for version validation"
+        )
+        return dict(config_obj)
+
+    model_dump = getattr(config_obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            dumped_config = model_dump()
+            logger.debug(
+                f"Converted Pydantic model {type(config_obj).__name__} to dictionary via model_dump for version validation"
+            )
+            return dumped_config
+        except Exception as exc:
+            logger.debug(
+                f"Failed to convert configuration {type(config_obj).__name__} using model_dump(): {exc}"
+            )
+
+    to_dict = getattr(config_obj, "to_dict", None)
+    if callable(to_dict):
+        try:
+            dict_config = to_dict()
+            logger.debug(
+                f"Converted configuration {type(config_obj).__name__} using to_dict() for version validation"
+            )
+            return dict_config
+        except Exception as exc:
+            logger.debug(
+                f"Failed to convert configuration {type(config_obj).__name__} using to_dict(): {exc}"
+            )
+
+    raise TypeError(
+        f"Configuration data must be dict-like or convertible, got {type(config_obj)}"
+    )
+
+
+def _attach_metadata_bucket(
+    discovery_result: Union[List[str], Dict[str, Any]],
+) -> Union[List[str], Dict[str, Dict[str, Any]]]:
+    """Ensure discovery results provide a nested ``metadata`` dictionary."""
+
+    if not isinstance(discovery_result, dict):
+        return discovery_result
+
+    normalised: Dict[str, Dict[str, Any]] = {}
+
+    for path, payload in discovery_result.items():
+        path_str = str(path)
+
+        if not isinstance(payload, dict):
+            normalised[path_str] = {"path": path_str, "metadata": {}}
+            continue
+
+        flattened = dict(payload)
+        flattened.setdefault("path", path_str)
+
+        existing_metadata = flattened.get("metadata")
+        metadata_bucket: Dict[str, Any] = {}
+        if isinstance(existing_metadata, dict):
+            metadata_bucket.update(existing_metadata)
+
+        flattened["metadata"] = metadata_bucket
+        normalised[path_str] = flattened  # type: ignore[assignment]
+
+    return normalised
+
+
+def _resolve_base_directory(
+    config: Union[Dict[str, Any], LegacyConfigAdapter],
+    base_directory: Optional[Union[str, Path]],
+    operation_name: str,
+) -> Union[str, Path]:
+    """Resolve base directory following documented precedence order."""
+
+    logger.debug(f"Starting base directory resolution for {operation_name}")
+    logger.debug(
+        "Resolution precedence: 1) explicit parameter, 2) config major_data_directory, 3) FLYRIGLOADER_DATA_DIR env var"
+    )
+
+    resolved_directory: Optional[Union[str, Path]] = None
+    resolution_source: Optional[str] = None
+
+    if base_directory is not None:
+        resolved_directory = base_directory
+        resolution_source = "explicit function parameter"
+        logger.info(f"Using explicit base_directory parameter: {base_directory}")
+        logger.debug(f"Resolution source: {resolution_source} (precedence 1)")
+
+    if resolved_directory is None:
+        logger.debug("No explicit base_directory provided, checking config for major_data_directory")
+
+        config_directory = None
+        if hasattr(config, "get"):
+            config_directory = (
+                config.get("project", {})  # type: ignore[arg-type]
+                .get("directories", {})
+                .get("major_data_directory")
+            )
+        else:
+            logger.warning(f"Unexpected config type for {operation_name}: {type(config)}")
+
+        if config_directory:
+            resolved_directory = config_directory
+            resolution_source = "configuration major_data_directory"
+            logger.info(f"Using major_data_directory from config: {config_directory}")
+            logger.debug(f"Resolution source: {resolution_source} (precedence 2)")
+        else:
+            logger.debug("No major_data_directory found in config")
+
+    if resolved_directory is None:
+        logger.debug("No config major_data_directory found, checking FLYRIGLOADER_DATA_DIR environment variable")
+        env_directory = os.environ.get("FLYRIGLOADER_DATA_DIR")
+
+        if env_directory:
+            resolved_directory = env_directory
+            resolution_source = "FLYRIGLOADER_DATA_DIR environment variable"
+            logger.info(f"Using FLYRIGLOADER_DATA_DIR environment variable: {env_directory}")
+            logger.debug(f"Resolution source: {resolution_source} (precedence 3)")
+        else:
+            logger.debug("No FLYRIGLOADER_DATA_DIR environment variable found")
+
+    if not resolved_directory:
+        error_msg = (
+            f"No data directory specified for {operation_name}. "
+            "Tried all resolution methods in precedence order:\n"
+            "1. Explicit 'base_directory' parameter (not provided)\n"
+            "2. Configuration 'project.directories.major_data_directory' (not found)\n"
+            "3. Environment variable 'FLYRIGLOADER_DATA_DIR' (not set)\n\n"
+            "Please provide a data directory using one of these methods:\n"
+            "- Pass base_directory parameter to the function\n"
+            "- Set 'major_data_directory' in your config:\n"
+            "  project:\n    directories:\n      major_data_directory: /path/to/data\n"
+            "- Set environment variable: export FLYRIGLOADER_DATA_DIR=/path/to/data"
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    resolved_path = Path(resolved_directory)
+
+    if resolved_path.exists():
+        logger.debug(f"Resolved directory exists: {resolved_path}")
+    else:
+        logger.warning(f"Resolved directory does not exist: {resolved_path}")
+        logger.warning(f"This may cause file discovery failures in {operation_name}")
+
+    logger.info(f"✓ Base directory resolution complete for {operation_name}")
+    logger.info(f"  Resolved path: {resolved_directory}")
+    logger.info(f"  Resolution source: {resolution_source}")
+    logger.debug(f"  Absolute path: {resolved_path.resolve()}")
+
+    return resolved_directory
+
+
+def get_default_column_config(
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> ColumnConfigDict:
+    """Get the default column configuration with enhanced testability."""
+
+    operation_name = "get_default_column_config"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.info("Loading default column configuration")
+
+    try:
+        result = _deps.io.get_config_from_source(None)
+
+        if hasattr(result, "columns"):
+            column_count = len(result.columns) if hasattr(result.columns, "__len__") else 0
+            logger.info(f"Successfully loaded default configuration with {column_count} columns")
+            logger.debug(
+                f"Column names: {list(result.columns.keys()) if hasattr(result.columns, 'keys') else 'N/A'}"
+            )
+        else:
+            logger.info(f"Successfully loaded default configuration, type: {type(result).__name__}")
+
+        return result
+    except Exception as exc:
+        error_msg = (
+            f"Failed to load default column configuration for {operation_name}: {exc}. "
+            "Please ensure the default configuration file exists and is valid."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def get_file_statistics(
+    path: Union[str, Path],
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Dict[str, Any]:
+    """Get comprehensive statistics for a file with enhanced testability."""
+
+    operation_name = "get_file_statistics"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug(f"Getting file statistics for: {path}")
+
+    if not path:
+        error_msg = (
+            f"Invalid path for {operation_name}: '{path}'. "
+            "Path must be a non-empty string or Path object."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    try:
+        result = _deps.utils.get_file_stats(path)
+        logger.debug(f"File statistics result: {result}")
+        return result
+    except FileNotFoundError as exc:
+        error_msg = (
+            f"File not found for {operation_name}: {path}. "
+            "Please ensure the file exists and the path is correct."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+    except Exception as exc:
+        error_msg = (
+            f"Failed to get file statistics for {operation_name}: {exc}. "
+            "Please check the path format."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def ensure_dir_exists(
+    path: Union[str, Path],
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Path:
+    """Ensure a directory exists, creating it if necessary."""
+
+    operation_name = "ensure_dir_exists"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug(f"Ensuring directory exists: {path}")
+
+    if not path:
+        error_msg = (
+            f"Invalid path for {operation_name}: '{path}'. "
+            "Path must be a non-empty string or Path object."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    try:
+        result = _deps.utils.ensure_directory_exists(path)
+        logger.debug(f"Directory ensured: {result}")
+        return result
+    except Exception as exc:
+        error_msg = (
+            f"Failed to ensure directory exists for {operation_name}: {exc}. "
+            "Please check the path format and permissions."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def check_if_file_exists(
+    path: Union[str, Path],
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> bool:
+    """Check whether a file exists."""
+
+    operation_name = "check_if_file_exists"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug(f"Checking if file exists: {path}")
+
+    if not path:
+        error_msg = (
+            f"Invalid path for {operation_name}: '{path}'. "
+            "Path must be a non-empty string or Path object."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    try:
+        result = _deps.utils.check_file_exists(path)
+        logger.debug(f"File exists: {result}")
+        return result
+    except Exception as exc:
+        error_msg = (
+            f"Failed to check file existence for {operation_name} at {path}: {exc}. "
+            "Please check the path format."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def _raise_path_validation_error(prefix: str, operation_name: str, path_value: Any, suffix: str) -> None:
+    """Raise a path validation error with standardized formatting."""
+
+    error_msg = f"{prefix}{operation_name}: '{path_value}{suffix}"
+    logger.error(error_msg)
+    raise FlyRigLoaderError(error_msg)
+
+
+def get_path_relative_to(
+    path: Union[str, Path],
+    base_dir: Union[str, Path],
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Path:
+    """Get a path relative to a base directory with enhanced testability."""
+
+    operation_name = "get_path_relative_to"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug(f"Getting relative path: {path} relative to {base_dir}")
+
+    if not path:
+        _raise_path_validation_error(
+            "Invalid path for ",
+            operation_name,
+            path,
+            "'. path must be a non-empty string or Path object.",
+        )
+    if not base_dir:
+        _raise_path_validation_error(
+            "Invalid base_dir for ",
+            operation_name,
+            base_dir,
+            "'. base_dir must be a non-empty string or Path object.",
+        )
+    try:
+        result = _deps.utils.get_relative_path(path, base_dir)
+        logger.debug(f"Relative path result: {result}")
+        return result
+    except ValueError as exc:
+        error_msg = (
+            f"Path {path} is not within base directory {base_dir} for {operation_name}. "
+            "Please ensure the path is within the specified base directory."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+    except Exception as exc:
+        error_msg = (
+            f"Failed to get relative path for {operation_name}: {exc}. "
+            "Please check the path formats."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def get_path_absolute(
+    path: Union[str, Path],
+    base_dir: Union[str, Path],
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Path:
+    """Convert a relative path to an absolute path with enhanced testability."""
+
+    operation_name = "get_path_absolute"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug(f"Getting absolute path: {path} with base {base_dir}")
+
+    if not path:
+        _raise_path_validation_error(
+            "Invalid path for ",
+            operation_name,
+            path,
+            "'. path must be a non-empty string or Path object.",
+        )
+    if not base_dir:
+        _raise_path_validation_error(
+            "Invalid base_dir for ",
+            operation_name,
+            base_dir,
+            "'. base_dir must be a non-empty string or Path object.",
+        )
+    try:
+        result = _deps.utils.get_absolute_path(path, base_dir)
+        logger.debug(f"Absolute path result: {result}")
+        return result
+    except Exception as exc:
+        error_msg = (
+            f"Failed to get absolute path for {operation_name}: {exc}. "
+            "Please check the path formats."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def get_common_base_dir(
+    paths: List[Union[str, Path]],
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Optional[Path]:
+    """Find the common base directory for a list of paths with enhanced testability."""
+
+    operation_name = "get_common_base_dir"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug(f"Finding common base directory for {len(paths) if paths else 0} paths")
+
+    if not isinstance(paths, list):
+        error_msg = (
+            f"Invalid paths parameter for {operation_name}: {type(paths).__name__}. "
+            "paths must be a list of path strings or Path objects."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    if not paths:
+        logger.debug("Empty paths list provided, returning None")
+        return None
+
+    for idx, path in enumerate(paths):
+        if not path:
+            error_msg = (
+                f"Invalid path at index {idx} for {operation_name}: '{path}'. "
+                "All paths must be non-empty strings or Path objects."
+            )
+            logger.error(error_msg)
+            raise FlyRigLoaderError(error_msg)
+
+    try:
+        result = _deps.utils.find_common_base_directory(paths)
+        if result:
+            logger.debug(f"Found common base directory: {result}")
+        else:
+            logger.debug("No common base directory found")
+        return result
+    except Exception as exc:
+        error_msg = (
+            f"Failed to find common base directory for {operation_name}: {exc}. "
+            "Please check the path formats."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
 
 __all__ = [
     "CONFIG_SOURCE_ERROR_MESSAGE",
@@ -39,3 +607,4 @@ __all__ = [
     "get_path_absolute",
     "get_path_relative_to",
 ]
+

--- a/src/flyrigloader/api/manifest.py
+++ b/src/flyrigloader/api/manifest.py
@@ -2,9 +2,300 @@
 
 from __future__ import annotations
 
-from ._core import discover_experiment_manifest, validate_manifest
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
 
-__all__ = [
-    "discover_experiment_manifest",
-    "validate_manifest",
-]
+from semantic_version import Version
+
+from flyrigloader import logger
+from flyrigloader.config.models import LegacyConfigAdapter
+from flyrigloader.config.validators import validate_config_version
+from flyrigloader.config.versioning import CURRENT_SCHEMA_VERSION
+from flyrigloader.discovery.files import discover_experiment_manifest as _discover_experiment_manifest
+from flyrigloader.exceptions import FlyRigLoaderError
+
+from ._shared import resolve_api_override
+from .config import (
+    _coerce_config_for_version_validation,
+    _load_and_validate_config,
+    _resolve_config_source,
+)
+from .dependencies import DefaultDependencyProvider, get_dependency_provider
+
+
+def discover_experiment_manifest(
+    config: Optional[Union[Dict[str, Any], LegacyConfigAdapter, Any]] = None,
+    experiment_name: str = "",
+    config_path: Optional[Union[str, Path]] = None,
+    base_directory: Optional[Union[str, Path]] = None,
+    pattern: str = "*.*",
+    recursive: bool = True,
+    extensions: Optional[List[str]] = None,
+    extract_metadata: bool = True,
+    parse_dates: bool = True,
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Discover experiment files and return a comprehensive manifest."""
+
+    operation_name = "discover_experiment_manifest"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.info(f"🔍 Discovering experiment manifest for '{experiment_name}'")
+    logger.debug(
+        "Discovery parameters: base_directory=%s, pattern=%s, recursive=%s, extensions=%s, "
+        "extract_metadata=%s, parse_dates=%s",
+        base_directory,
+        pattern,
+        recursive,
+        extensions,
+        extract_metadata,
+        parse_dates,
+    )
+
+    if not experiment_name or not isinstance(experiment_name, str):
+        error_msg = (
+            f"Invalid experiment_name for {operation_name}: '{experiment_name}'. "
+            "experiment_name must be a non-empty string representing the experiment identifier."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    config_dict = _resolve_config_source(config, config_path, operation_name, _deps)
+
+    try:
+        logger.debug("Starting decoupled file discovery for experiment '%s'", experiment_name)
+
+        discover_manifest = resolve_api_override(
+            globals(), "_discover_experiment_manifest", _discover_experiment_manifest
+        )
+
+        file_manifest = discover_manifest(
+            config=config_dict,
+            experiment_name=experiment_name,
+            patterns=None,
+            parse_dates=parse_dates,
+            include_stats=extract_metadata,
+            test_mode=False,
+        )
+
+        manifest_dict: Dict[str, Dict[str, Any]] = {}
+        for file_info in file_manifest.files:
+            if isinstance(file_info.extracted_metadata, dict):
+                metadata_payload = dict(file_info.extracted_metadata)
+            else:
+                metadata_payload = {}
+
+            manifest_entry: Dict[str, Any] = {
+                "path": file_info.path,
+                "size": file_info.size if file_info.size is not None else 0,
+                "metadata": metadata_payload,
+                "parsed_dates": {"parsed_date": file_info.parsed_date} if file_info.parsed_date else {},
+            }
+
+            if file_info.mtime is not None:
+                manifest_entry["mtime"] = file_info.mtime
+            if file_info.ctime is not None:
+                manifest_entry["ctime"] = file_info.ctime
+            if file_info.creation_time is not None:
+                manifest_entry["creation_time"] = file_info.creation_time
+
+            manifest_dict[file_info.path] = manifest_entry
+
+        file_count = len(manifest_dict)
+        total_size = sum(item.get("size", 0) for item in manifest_dict.values())
+        logger.info("✓ Discovered %s files for experiment '%s'", file_count, experiment_name)
+        logger.info("  Total data size: %s bytes (%0.1f MB)", total_size, total_size / (1024**2) if total_size else 0.0)
+        sample_files = list(manifest_dict.keys())[:3]
+        suffix = "..." if file_count > 3 else ""
+        logger.debug("  Sample files: %s%s", sample_files, suffix)
+
+        return manifest_dict
+
+    except Exception as exc:
+        error_msg = (
+            f"Failed to discover experiment manifest for '{experiment_name}': {exc}. "
+            "Please check the experiment configuration and data directory structure."
+        )
+        logger.error(error_msg)
+        raise RuntimeError(error_msg) from exc
+
+
+def validate_manifest(
+    manifest: Dict[str, Dict[str, Any]],
+    config: Optional[Union[Dict[str, Any], Any]] = None,
+    config_path: Optional[Union[str, Path]] = None,
+    strict_validation: bool = False,
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Dict[str, Any]:
+    """Validate an experiment manifest for pre-flight validation without side effects."""
+
+    operation_name = "validate_manifest"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.info(f"🔍 Validating experiment manifest with {len(manifest)} files")
+    logger.debug("Validation parameters: strict_validation=%s", strict_validation)
+
+    if not isinstance(manifest, dict):
+        error_msg = (
+            f"Invalid manifest parameter for {operation_name}: expected dict, got {type(manifest).__name__}. "
+            "manifest must be a dictionary from discover_experiment_manifest()."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg)
+
+    if not manifest:
+        logger.warning("Empty manifest provided for validation")
+        return {
+            "valid": True,
+            "file_count": 0,
+            "errors": [],
+            "warnings": ["Empty manifest - no files to validate"],
+            "metadata": {"validation_type": "empty_manifest"},
+        }
+
+    validation_report: Dict[str, Any] = {
+        "valid": True,
+        "file_count": len(manifest),
+        "errors": [],
+        "warnings": [],
+        "metadata": {
+            "validation_type": "strict" if strict_validation else "basic",
+            "validated_files": [],
+            "failed_files": [],
+            "total_size_bytes": 0,
+        },
+    }
+
+    try:
+        config_dict = None
+        if config is not None or config_path is not None:
+            try:
+                if config is not None:
+                    config_dict = config
+                    logger.debug("Using provided configuration for validation rules")
+                else:
+                    config_dict = _load_and_validate_config(config_path, None, operation_name, _deps)
+                    logger.debug(f"Loaded configuration from {config_path} for validation")
+            except Exception as exc:
+                validation_report["warnings"].append(
+                    f"Failed to load configuration for validation: {exc}"
+                )
+                logger.warning("Configuration loading failed, proceeding with basic validation: %s", exc)
+
+        for file_path, file_metadata in manifest.items():
+            try:
+                logger.debug("Validating file: %s", file_path)
+
+                if not isinstance(file_metadata, dict):
+                    error_msg = (
+                        f"Invalid metadata for file {file_path}: expected dict, got {type(file_metadata).__name__}"
+                    )
+                    validation_report["errors"].append(error_msg)
+                    validation_report["metadata"]["failed_files"].append(file_path)
+                    continue
+
+                required_fields = ["path", "size"]
+                for field in required_fields:
+                    if field not in file_metadata:
+                        validation_report["warnings"].append(
+                            f"Missing metadata field '{field}' for file {file_path}"
+                        )
+
+                if strict_validation:
+                    file_path_obj = Path(file_path)
+                    if not file_path_obj.exists():
+                        error_msg = f"File does not exist: {file_path}"
+                        validation_report["errors"].append(error_msg)
+                        validation_report["metadata"]["failed_files"].append(file_path)
+                        continue
+
+                    if not file_path_obj.is_file():
+                        error_msg = f"Path is not a regular file: {file_path}"
+                        validation_report["errors"].append(error_msg)
+                        validation_report["metadata"]["failed_files"].append(file_path)
+                        continue
+
+                    actual_size = file_path_obj.stat().st_size
+                    reported_size = file_metadata.get("size", 0)
+                    if abs(actual_size - reported_size) > 1024:
+                        validation_report["warnings"].append(
+                            f"Size mismatch for {file_path}: reported {reported_size}, actual {actual_size}"
+                        )
+
+                file_size = file_metadata.get("size", 0)
+                if isinstance(file_size, (int, float)):
+                    validation_report["metadata"]["total_size_bytes"] += file_size
+
+                validation_report["metadata"]["validated_files"].append(file_path)
+
+            except Exception as exc:
+                error_msg = f"Validation failed for file {file_path}: {exc}"
+                validation_report["errors"].append(error_msg)
+                validation_report["metadata"]["failed_files"].append(file_path)
+                logger.error(error_msg)
+
+        if config_dict is not None:
+            try:
+                normalized_config = _coerce_config_for_version_validation(config_dict)
+                is_valid, detected_version, message = validate_config_version(normalized_config)
+                validation_report["metadata"]["config_version"] = str(detected_version)
+                logger.debug("Detected configuration version: %s", detected_version)
+
+                current_version = Version(CURRENT_SCHEMA_VERSION)
+                config_version = Version(str(detected_version))
+
+                if not is_valid:
+                    validation_report["errors"].append(message)
+                elif config_version < current_version:
+                    validation_report["warnings"].append(
+                        f"Configuration version {detected_version} is older than supported version {CURRENT_SCHEMA_VERSION}."
+                    )
+                elif config_version > current_version:
+                    validation_report["errors"].append(
+                        f"Configuration version {detected_version} is newer than supported version {CURRENT_SCHEMA_VERSION}. "
+                        "Please upgrade FlyRigLoader."
+                    )
+
+            except Exception as exc:
+                validation_report["warnings"].append(
+                    f"Configuration version validation failed: {exc}"
+                )
+                logger.warning("Configuration version validation error: %s", exc)
+
+        validation_report["valid"] = len(validation_report["errors"]) == 0
+
+        if validation_report["valid"]:
+            logger.info(
+                "✓ Manifest validation successful: %s files validated", validation_report["file_count"]
+            )
+            if validation_report["warnings"]:
+                logger.info("  Warnings: %s", len(validation_report["warnings"]))
+        else:
+            logger.error(
+                "✗ Manifest validation failed: %s errors, %s warnings",
+                len(validation_report["errors"]),
+                len(validation_report["warnings"]),
+            )
+
+        logger.debug(
+            "Validation summary: %s bytes total",
+            validation_report["metadata"]["total_size_bytes"],
+        )
+
+        return validation_report
+
+    except Exception as exc:
+        error_msg = (
+            f"Manifest validation failed for {operation_name}: {exc}. "
+            "Please check the manifest structure and validation parameters."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+__all__ = ["discover_experiment_manifest", "validate_manifest"]
+

--- a/src/flyrigloader/api/registry.py
+++ b/src/flyrigloader/api/registry.py
@@ -2,9 +2,165 @@
 
 from __future__ import annotations
 
-from ._core import get_loader_capabilities, get_registered_loaders
+from typing import Any, Dict, Optional
 
-__all__ = [
-    "get_loader_capabilities",
-    "get_registered_loaders",
-]
+from flyrigloader import logger
+from flyrigloader.exceptions import FlyRigLoaderError
+from flyrigloader.registries import get_loader_capabilities as _get_loader_capabilities
+
+from .dependencies import DefaultDependencyProvider, get_dependency_provider
+
+
+def get_registered_loaders(
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Return comprehensive information about registered file loaders."""
+
+    operation_name = "get_registered_loaders"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug("🔍 Retrieving registered loader information")
+
+    try:
+        from flyrigloader.registries import LoaderRegistry
+
+        registry = LoaderRegistry()
+        loader_info: Dict[str, Dict[str, Any]] = {}
+
+        all_loaders = registry.get_all_loaders()
+        registered_extensions = list(all_loaders.keys())
+        logger.debug("Found %s registered extensions", len(registered_extensions))
+
+        for extension in registered_extensions:
+            try:
+                loader_class = registry.get_loader_for_extension(extension)
+                capabilities = _get_loader_capabilities(extension)
+
+                loader_info[extension] = {
+                    "loader_class": loader_class.__name__ if hasattr(loader_class, "__name__") else str(loader_class),
+                    "supported_extensions": [extension],
+                    "priority": getattr(loader_class, "priority", "BUILTIN"),
+                    "capabilities": capabilities,
+                    "metadata": {
+                        "module": getattr(loader_class, "__module__", "unknown"),
+                        "registered": True,
+                        "extension_primary": extension,
+                    },
+                }
+
+                if hasattr(loader_class, "supported_extensions"):
+                    additional_extensions = [
+                        ext for ext in loader_class.supported_extensions if ext != extension and ext in registered_extensions
+                    ]
+                    if additional_extensions:
+                        loader_info[extension]["supported_extensions"].extend(additional_extensions)
+
+                logger.debug("Retrieved information for loader: %s", extension)
+
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning("Failed to get information for extension %s: %s", extension, exc)
+                loader_info[extension] = {
+                    "loader_class": "unknown",
+                    "supported_extensions": [extension],
+                    "priority": "unknown",
+                    "capabilities": {},
+                    "metadata": {
+                        "error": str(exc),
+                        "registered": True,
+                        "extension_primary": extension,
+                    },
+                }
+
+        logger.info("✓ Retrieved information for %s registered loaders", len(loader_info))
+        logger.debug("  Extensions: %s", list(loader_info.keys()))
+
+        return loader_info
+
+    except Exception as exc:
+        error_msg = (
+            f"Failed to retrieve registered loaders for {operation_name}: {exc}. "
+            "Please check the registry system and loader registrations."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+def get_loader_capabilities(
+    extension: Optional[str] = None,
+    _deps: Optional[DefaultDependencyProvider] = None,
+) -> Dict[str, Any]:
+    """Return capability metadata for registered file loaders."""
+
+    operation_name = "get_loader_capabilities"
+
+    if _deps is None:
+        _deps = get_dependency_provider()
+
+    logger.debug("🔍 Retrieving loader capabilities for extension: %s", extension or "all")
+
+    try:
+        if extension is not None:
+            if not extension or not isinstance(extension, str):
+                error_msg = (
+                    f"Invalid extension for {operation_name}: '{extension}'. "
+                    "extension must be a non-empty string (e.g., '.pkl')."
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            capabilities = _get_loader_capabilities(extension)
+
+            if not capabilities:
+                error_msg = (
+                    f"No loader registered for extension '{extension}'. "
+                    "Please check the extension format and ensure a loader is registered."
+                )
+                logger.error(error_msg)
+                raise ValueError(error_msg)
+
+            logger.debug("Retrieved capabilities for extension %s", extension)
+            return capabilities
+
+        from flyrigloader.registries import LoaderRegistry
+
+        registry = LoaderRegistry()
+        all_loaders = registry.get_all_loaders()
+        registered_extensions = list(all_loaders.keys())
+
+        all_capabilities: Dict[str, Dict[str, Any]] = {}
+        for ext in registered_extensions:
+            try:
+                capabilities = _get_loader_capabilities(ext)
+                all_capabilities[ext] = capabilities
+                logger.debug("Retrieved capabilities for extension %s", ext)
+            except Exception as exc:  # pragma: no cover - defensive logging
+                logger.warning("Failed to get capabilities for extension %s: %s", ext, exc)
+                all_capabilities[ext] = {
+                    "streaming_support": False,
+                    "compression_support": [],
+                    "metadata_extraction": False,
+                    "performance_profile": {"status": "unknown"},
+                    "memory_efficiency": {"rating": "unknown"},
+                    "thread_safety": {"safe": False},
+                    "error": str(exc),
+                }
+
+        logger.info("✓ Retrieved capabilities for %s loaders", len(all_capabilities))
+        return all_capabilities
+
+    except Exception as exc:
+        if isinstance(exc, ValueError):
+            raise
+
+        error_msg = (
+            f"Failed to retrieve loader capabilities for {operation_name}: {exc}. "
+            "Please check the registry system and loader implementations."
+        )
+        logger.error(error_msg)
+        raise FlyRigLoaderError(error_msg) from exc
+
+
+__all__ = ["get_loader_capabilities", "get_registered_loaders"]
+

--- a/tests/flyrigloader/test_api_submodule_independence.py
+++ b/tests/flyrigloader/test_api_submodule_independence.py
@@ -1,0 +1,51 @@
+"""Tests ensuring API submodules are decoupled from :mod:`flyrigloader.api._core`."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections.abc import Iterable
+
+import pytest
+
+
+class _ExplosiveCore(types.ModuleType):
+    """Module stub that fails loudly when any attribute access occurs."""
+
+    def __getattr__(self, item: str) -> object:  # pragma: no cover - defensive guard
+        raise AssertionError(f"Unexpected access to api._core attribute '{item}' during import")
+
+
+def _clear_api_modules(exceptions: Iterable[str] = ()) -> None:
+    """Remove cached flyrigloader.api modules except those explicitly exempted."""
+
+    preserved = tuple(exceptions)
+    for name in list(sys.modules):
+        if not name.startswith("flyrigloader.api"):
+            continue
+        if name in preserved:
+            continue
+        sys.modules.pop(name)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "expected_symbols"),
+    [
+        ("config", ["_load_and_validate_config", "ensure_dir_exists", "get_path_absolute"]),
+        ("manifest", ["discover_experiment_manifest", "validate_manifest"]),
+        ("registry", ["get_loader_capabilities", "get_registered_loaders"]),
+    ],
+)
+def test_api_submodule_import_does_not_require_core(monkeypatch: pytest.MonkeyPatch, module_name: str, expected_symbols: list[str]) -> None:
+    """Verify targeted submodules import successfully without depending on _core."""
+
+    _clear_api_modules()
+
+    monkeypatch.setitem(sys.modules, "flyrigloader.api._core", _ExplosiveCore("flyrigloader.api._core"))
+
+    submodule = importlib.import_module(f"flyrigloader.api.{module_name}")
+
+    for symbol in expected_symbols:
+        assert hasattr(submodule, symbol), f"Expected {symbol} on flyrigloader.api.{module_name}"
+


### PR DESCRIPTION
## Summary
- implement the configuration, manifest, and registry helpers directly in their respective submodules
- add a shared override helper and lazily expose core entry points from flyrigloader.api
- guard the new structure with tests that ensure submodules import without touching api._core

## Testing
- pytest tests/flyrigloader/test_api_submodule_independence.py
- pytest tests/flyrigloader/test_load_and_validate_config.py


------
https://chatgpt.com/codex/tasks/task_e_68d45561625c8320bd67aef1db813900