### PR TITLE
docs: add architecture overview and maintenance checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to FlyRigLoader
+
+FlyRigLoader emphasizes fail-fast behavior, traceable logging, and well-curated
+documentation. The following guidelines help keep the README, architecture
+overview, and topical guides aligned with the evolving feature set.
+
+## Workflow Expectations
+
+- **Plan with tests first** – adopt a red/green/refactor loop and design tests to
+  confirm observable results rather than implementation details.
+- **Fail loud and fast** – validate inputs aggressively and raise
+  `FlyRigLoaderError` subclasses when assumptions break instead of falling back to
+  ambiguous states.【F:src/flyrigloader/exceptions.py†L1-L147】
+- **Prefer explicit configuration** – use helper builders from
+  `flyrigloader.config` instead of ad-hoc dictionaries so validation errors appear
+  early.【F:src/flyrigloader/config/builder.py†L1-L120】
+- **Embrace verbose logging** – call `initialize_logger()` during manual testing
+  and ensure new code paths emit contextual `logger.info`/`logger.debug` messages
+  rather than muting diagnostics.【F:src/flyrigloader/__init__.py†L122-L248】【F:src/flyrigloader/api/_core.py†L176-L213】
+
+## Documentation Alignment Checklist
+
+Run through this checklist before merging any change that adds behavior, alters
+configuration, or adjusts logging:
+
+1. **README** – confirm feature lists, usage examples, and logging instructions
+   still match reality. Add cross-links to new topical docs when applicable.
+2. **Architecture Overview** – update module responsibilities, diagrams, and the
+   maintenance checklist in `docs/architecture.md` to reflect new flow control.
+3. **Configuration Guide** – document new schema fields, defaults, or resolution
+   rules in `docs/configuration_guide.md`.
+4. **Extension Guide** – describe new registry hooks or plugin patterns in
+   `docs/extension_guide.md`, including logging expectations for third-party
+   integrations.
+5. **Changelogs / Release notes** – call out logging level changes or new sinks
+   so operators can adjust verbosity settings promptly.
+
+## Logging Standards
+
+- Default to `INFO` level console messages and `DEBUG` level file messages unless
+  there is a compelling reason to diverge. Adjust levels temporarily for tests by
+  constructing a custom `LoggerConfig`.
+- Include operation identifiers and key parameters in log messages so correlating
+  file activity with downstream data frames remains straightforward.【F:src/flyrigloader/api/_core.py†L176-L213】【F:src/flyrigloader/api/_core.py†L308-L376】
+- Never swallow exceptions; raise with context and allow the logger to capture
+  stack traces.
+- When adding third-party integrations, verify they honor the Loguru intercept so
+  logs stay centralized. If a library requires custom handling, document it in the
+  architecture guide.
+
+## Configuration Guidance
+
+- Use `create_config()` or the YAML loaders from `flyrigloader.api.config` to
+  ensure inputs are validated and versioned.【F:src/flyrigloader/api/config.py†L40-L153】
+- Keep sensitive paths out of committed configuration files; only reference them
+  through validated directory fields.
+- Avoid introducing environment-variable driven logic unless dealing with secret
+  material.
+
+## Pull Request Checklist
+
+- [ ] Tests cover observable behavior and fail before the fix is applied.
+- [ ] Logging statements clearly describe the new workflow and remain consistent
+      with verbosity standards.
+- [ ] Documentation (README, architecture, configuration, extension guides) is
+      updated or explicitly confirmed as unchanged.
+- [ ] Added extension points are registered and documented with usage examples.
+- [ ] No unexpected fallbacks or silent error handling paths remain.
+
+Adhering to this checklist keeps the codebase predictable and the documentation
+authoritative for both maintainers and downstream data analysts.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ from flyrigloader.logger import initialize_logger
 initialize_logger()
 ```
 
+## Architecture & Maintenance Resources
+
+- 📐 **Architecture Overview** – [docs/architecture.md](docs/architecture.md)
+  captures module responsibilities, boot flow, and extension seams at a glance.
+- 🧭 **Configuration Guide** – [docs/configuration_guide.md](docs/configuration_guide.md)
+  documents schema models, path resolution, and validation patterns.
+- 🔌 **Extension Guide** – [docs/extension_guide.md](docs/extension_guide.md) explains how
+  to register loaders and schemas through the registry infrastructure.
+- 🛠️ **Contributing Checklist** – [CONTRIBUTING.md](CONTRIBUTING.md) outlines how to keep
+  documentation aligned with feature work and reinforces logging expectations.
+
 Example usage:
 
 ```python

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,123 @@
+# FlyRigLoader Architecture Overview
+
+This document summarizes how the refactored FlyRigLoader package is organized, how the
+runtime boot flow progresses from configuration to data products, and where
+maintainers can extend the system safely. Cross-references to topical guides are
+provided throughout so feature documentation remains synchronized.
+
+## High-Level System Layers
+
+FlyRigLoader is organized into layered modules that separate configuration,
+discovery, loading, transformation, and orchestration concerns:
+
+- **`flyrigloader.config`** – Defines Pydantic models, builders, validators, and
+  versioning helpers for configuration management.【F:src/flyrigloader/config/__init__.py†L1-L18】【F:src/flyrigloader/config/models.py†L1-L46】
+- **`flyrigloader.discovery`** – Provides manifest generation utilities and file
+  discovery helpers with metadata extraction support.【F:src/flyrigloader/discovery/files.py†L1-L189】
+- **`flyrigloader.io`** – Houses loader implementations, transformation
+  pipelines, and column configuration helpers used once files are selected.【F:src/flyrigloader/io/loaders.py†L1-L187】【F:src/flyrigloader/io/transformers.py†L1-L210】
+- **`flyrigloader.registries`** – Supplies registry singletons and capability
+  queries that make the loader and schema layers pluggable.【F:src/flyrigloader/registries/__init__.py†L1-L120】
+- **`flyrigloader.api`** – Coordinates dependency providers, manifest discovery,
+  and data loading in a backwards-compatible façade consumed by downstream
+  tools.【F:src/flyrigloader/api/_core.py†L1-L120】【F:src/flyrigloader/api/dependencies.py†L1-L180】
+- **`flyrigloader` package root** – Exposes logging setup and shared utilities so
+  every layer can emit structured diagnostics consistently.【F:src/flyrigloader/__init__.py†L1-L120】
+
+Additional modules such as `flyrigloader.exceptions` and `flyrigloader.utils`
+provide domain-specific errors, path helpers, and test scaffolding that support
+all layers.【F:src/flyrigloader/exceptions.py†L1-L147】【F:src/flyrigloader/utils/paths.py†L1-L160】
+
+Refer to the [Configuration Guide](configuration_guide.md) and
+[Extension Guide](extension_guide.md) for in-depth coverage of specific layers.
+
+## Runtime Boot Flow
+
+The primary runtime sequence is designed to fail fast when configuration or file
+assumptions are violated while keeping data loading memory efficient.
+
+```
+┌─────────────────────┐
+│ initialize_logger() │  ⇢  Sets up Loguru sinks & bridges stdlib logging.【F:src/flyrigloader/__init__.py†L122-L274】
+└─────────┬───────────┘
+          │
+          ▼
+┌────────────────────────────┐
+│ create_config(...) / load │  ⇢  Build or load validated config models.【F:src/flyrigloader/config/builder.py†L1-L120】【F:src/flyrigloader/api/config.py†L40-L153】
+└──────────┬─────────────────┘
+           │
+           ▼
+┌───────────────────────────────┐
+│ discover_experiment_manifest │  ⇢  Produce manifest with metadata & audits.【F:src/flyrigloader/api/_core.py†L123-L256】
+└─────────────┬─────────────────┘
+              │
+              ▼
+┌──────────────────────────┐
+│ load_dataset_files(...) │  ⇢  Resolve loaders & stream files from registry.【F:src/flyrigloader/api/_core.py†L420-L610】【F:src/flyrigloader/io/loaders.py†L70-L187】
+└───────────┬──────────────┘
+            │
+            ▼
+┌────────────────────────────┐
+│ transform_to_dataframe(...)│ ⇢  Apply column models & return tidy frame.【F:src/flyrigloader/io/transformers.py†L77-L210】
+└────────────────────────────┘
+```
+
+Each stage records progress through `loguru` so analysts can correlate file
+operations with downstream results. Exceptions derived from `FlyRigLoaderError`
+propagate without silent fallbacks, aligning with the fail-fast policy.【F:src/flyrigloader/exceptions.py†L1-L147】
+
+## Logging Flow Notes
+
+The logging infrastructure intentionally centralizes configuration and maintains
+verbosity by default:
+
+- `initialize_logger()` installs both console and rotating file sinks, then
+  bridges stdlib logging through an `InterceptHandler` so third-party modules are
+  captured without extra plumbing.【F:src/flyrigloader/__init__.py†L122-L248】
+- Console output defaults to `INFO` while file logs capture `DEBUG` for full
+  traceability during investigations; contributors can override these levels via
+  `LoggerConfig` when diagnosing issues.【F:src/flyrigloader/__init__.py†L250-L356】
+- All API entry points include explicit info/debug statements describing
+  parameters, injected dependencies, and selection results to keep audits
+  readable.【F:src/flyrigloader/api/_core.py†L176-L213】【F:src/flyrigloader/api/_core.py†L308-L376】
+- When developing new features, prefer raising contextual exceptions over
+  suppressing errors so the log stream accurately reflects pipeline health.
+
+## Extension and Injection Points
+
+FlyRigLoader encourages extension through explicit registries and dependency
+providers:
+
+- **Loader & schema registries** – Register new loaders or validation schemas via
+  `LoaderRegistry`/`SchemaRegistry`, including priority controls and capability
+  queries for discovery-time diagnostics.【F:src/flyrigloader/registries/__init__.py†L1-L120】【F:src/flyrigloader/api/registry.py†L1-L98】
+- **Dependency provider overrides** – Use `set_dependency_provider()` during
+  testing or specialized deployments to swap discovery, IO, or utility
+  implementations without modifying the façade logic.【F:src/flyrigloader/api/dependencies.py†L1-L180】
+- **Configuration builders** – Compose validated configs programmatically through
+  `create_config()` and helper functions, ensuring downstream modules always see
+  typed models and consistent defaults.【F:src/flyrigloader/config/builder.py†L1-L120】
+- **Manifest hooks** – `discover_experiment_manifest` exposes metadata buckets
+  and audit trails that downstream tools can enrich or filter before loading
+  data.【F:src/flyrigloader/api/_core.py†L123-L320】
+
+When extending the system, update this architecture summary alongside the
+feature-specific guide so future contributors can reason about new seams quickly.
+
+## Maintenance Checklist
+
+Use the following checklist when merging architectural changes:
+
+1. Update module responsibilities and diagrams in this document to reflect new
+   flows.
+2. Verify README links point to the latest topical guides and add new sections as
+   needed.
+3. Document new configuration fields or defaults in the
+   [Configuration Guide](configuration_guide.md) and reference them from relevant
+   API docstrings.
+4. Describe new extension points in the [Extension Guide](extension_guide.md) and
+   add usage examples or logging expectations.
+5. Ensure logging behavior is covered in release notes and `initialize_logger`
+   guidance when verbosity levels or sinks change.
+
+For contributor workflow expectations, see [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -17,6 +17,8 @@
 
 FlyRigLoader has been completely modernized with a new Pydantic-based configuration system that provides:
 
+> **Need the bigger picture?** Review the [Architecture Overview](architecture.md) for module responsibilities and boot flow context before diving into configuration details.
+
 - **Type-safe configuration** with automatic validation
 - **Schema-driven approach** that prevents configuration errors at load time
 - **Hierarchical inheritance** from project → dataset → experiment levels

--- a/docs/extension_guide.md
+++ b/docs/extension_guide.md
@@ -18,6 +18,8 @@ This guide provides comprehensive documentation for extending FlyRigLoader throu
 
 FlyRigLoader implements a registry-based extensibility pattern that aligns with the SOLID Open/Closed principle, allowing the system to be open for extension but closed for modification. This architecture enables:
 
+> **First time extending the loader?** Start with the [Architecture Overview](architecture.md) to understand how discovery, IO, and registries cooperate before wiring a new plugin.
+
 - **Plugin-style extensibility**: New file formats and validation schemas can be added without modifying core code
 - **Thread-safe singleton implementation**: All registries use thread-safe singleton patterns with O(1) lookup performance
 - **Automatic plugin discovery**: Extensions can be discovered automatically through setuptools entry points


### PR DESCRIPTION
## Summary
- add a comprehensive architecture overview outlining module responsibilities, boot flow, extension seams, and logging behavior
- introduce a CONTRIBUTING guide with documentation alignment and logging standards checklists
- cross-link the new guidance throughout the README and topical docs to keep references synchronized

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d53485ccd483208cb09da560bd69c3