### PR TITLE
Fix discovery success logging noise

### DIFF
--- a/src/flyrigloader/discovery/enumeration.py
+++ b/src/flyrigloader/discovery/enumeration.py
@@ -64,7 +64,7 @@ class FileEnumerator:
         mandatory_substrings: Optional[List[str]] = None,
     ) -> List[str]:
         """Find files matching the supplied constraints."""
-        logger.info("Starting file discovery with pattern='%s', recursive=%s", pattern, recursive)
+        logger.debug("Starting file discovery with pattern='%s', recursive=%s", pattern, recursive)
         logger.debug("Search directories: %s", directory)
         logger.debug("Extensions filter: %s", extensions)
         logger.debug("Ignore patterns: %s", ignore_patterns)
@@ -92,14 +92,14 @@ class FileEnumerator:
                 if not self.test_mode:
                     raise
 
-        logger.info("Total files found before filtering: %d", len(all_matched_files))
+        logger.debug("Total files found before filtering: %d", len(all_matched_files))
         filtered_files = self._apply_filters(
             all_matched_files,
             extensions=extensions,
             ignore_patterns=ignore_patterns,
             mandatory_substrings=mandatory_substrings,
         )
-        logger.info("Final file count after filtering: %d", len(filtered_files))
+        logger.debug("Final file count after filtering: %d", len(filtered_files))
         return filtered_files
 
     def _glob(self, directory_path: Path, pattern: str, recursive: bool) -> List[Path]:

--- a/src/flyrigloader/discovery/files.py
+++ b/src/flyrigloader/discovery/files.py
@@ -452,7 +452,7 @@ class FileDiscoverer:
             "%Y%m%d_%H%M%S"
         ]
         
-        logger.info(f"FileDiscoverer initialized successfully with {len(self.date_formats)} date formats")
+        logger.debug(f"FileDiscoverer initialized successfully with {len(self.date_formats)} date formats")
     
     def _convert_to_named_patterns(self, patterns: List[str]) -> List[str]:
         """
@@ -568,7 +568,7 @@ class FileDiscoverer:
             if compatibility_fixes > 0:
                 logger.debug(f"Applied {compatibility_fixes} backward compatibility fixes")
             
-            logger.info(f"Metadata extraction completed for {len(result)} files")
+            logger.debug(f"Metadata extraction completed for {len(result)} files")
             return result
             
         except Exception as e:
@@ -663,7 +663,7 @@ class FileDiscoverer:
             file paths to extracted metadata (NO data loading occurs).
             Otherwise: List of matched file paths.
         """
-        logger.info(f"Starting file discovery process with pattern: {pattern}")
+        logger.debug(f"Starting file discovery process with pattern: {pattern}")
         logger.debug(f"Discovery options - patterns: {bool(self.extract_patterns)}, dates: {self.parse_dates}, stats: {self.include_stats}")
         
         try:
@@ -679,7 +679,7 @@ class FileDiscoverer:
             
             # Check if we need to return files with metadata
             if not (self.extract_patterns or self.parse_dates or self.include_stats or self.enable_kedro_metadata):
-                logger.info(f"Returning simple file list with {len(found_files)} files")
+                logger.debug(f"Returning simple file list with {len(found_files)} files")
                 return found_files
             
             logger.debug("Extracting metadata and additional information")
@@ -710,7 +710,7 @@ class FileDiscoverer:
                     if not self.test_mode:
                         raise
             
-            logger.info(f"Discovery completed successfully with {len(result)} files")
+            logger.debug(f"Discovery completed successfully with {len(result)} files")
             return result
             
         except Exception as e:
@@ -758,7 +758,7 @@ class FileDiscoverer:
         logger.debug(f"Registering new pattern matcher: {type(pattern_matcher).__name__}")
         self.pattern_matcher = pattern_matcher
         self.named_extract_patterns = getattr(pattern_matcher, 'patterns', None)
-        logger.info(f"Pattern matcher registered successfully: {type(pattern_matcher).__name__}")
+        logger.debug(f"Pattern matcher registered successfully: {type(pattern_matcher).__name__}")
     
     def get_supported_patterns(self) -> List[str]:
         """
@@ -1085,7 +1085,7 @@ def discover_experiment_manifest(
     Returns:
         FileManifest containing discovered files metadata with Kedro integration support
     """
-    logger.info(f"Discovering experiment manifest for '{experiment_name}'")
+    logger.debug(f"Discovering experiment manifest for '{experiment_name}'")
 
     try:
         # Normalize configuration input
@@ -1296,7 +1296,7 @@ def discover_experiment_manifest(
             except Exception as e:
                 logger.warning(f"Error generating Kedro catalog entries: {e}")
         
-        logger.info(f"Created enhanced manifest with {len(all_files)} files for experiment '{experiment_name}'")
+        logger.debug(f"Created enhanced manifest with {len(all_files)} files for experiment '{experiment_name}'")
         
         # Log version and Kedro statistics
         version_summary = manifest.get_version_summary()
@@ -1380,7 +1380,7 @@ def discover_files(
         Dictionary mapping file paths to extracted metadata (NO data loading occurs).
         Otherwise: List of matched file paths.
     """
-    logger.info(f"discover_files called with pattern='{pattern}', test_mode={test_mode}")
+    logger.debug(f"discover_files called with pattern='{pattern}', test_mode={test_mode}")
     
     try:
         normalized_directory = _normalize_directory_argument(directory)
@@ -1411,7 +1411,7 @@ def discover_files(
             mandatory_substrings=mandatory_substrings
         )
         
-        logger.info(f"discover_files completed successfully, returned {len(result) if isinstance(result, (list, dict)) else 'unknown'} items")
+        logger.debug(f"discover_files completed successfully, returned {len(result) if isinstance(result, (list, dict)) else 'unknown'} items")
         return result
         
     except Exception as e:
@@ -1478,7 +1478,7 @@ def get_latest_file(
                 raise
         
         latest_file = max(files, key=get_mtime)
-        logger.info(f"Latest file determined: {latest_file}")
+        logger.debug(f"Latest file determined: {latest_file}")
         return str(latest_file)
         
     except Exception as e:

--- a/tests/test_discovery_logging_quiet.py
+++ b/tests/test_discovery_logging_quiet.py
@@ -1,0 +1,98 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from flyrigloader.discovery.enumeration import FileEnumerator
+from flyrigloader.discovery.files import discover_experiment_manifest, discover_files
+
+
+def _write_file(path: Path, name: str) -> Path:
+    target = path / name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("content", encoding="utf-8")
+    return target
+
+
+@pytest.mark.parametrize("recursive", [False, True])
+def test_file_enumerator_routine_logs_are_debug_only(tmp_path: Path, caplog, recursive: bool) -> None:
+    data_dir = tmp_path / "data"
+    _write_file(data_dir, "a.txt")
+    _write_file(data_dir, "nested/b.txt")
+
+    enumerator = FileEnumerator()
+
+    caplog.set_level(logging.DEBUG)
+
+    results = enumerator.find_files(
+        directory=data_dir,
+        pattern="*.txt",
+        recursive=recursive,
+    )
+
+    expected = {str(data_dir / "a.txt")}
+    if recursive:
+        expected.add(str(data_dir / "nested" / "b.txt"))
+
+    assert set(results) == expected
+
+    info_messages = [record.message for record in caplog.records if record.levelno == logging.INFO]
+    assert all("file discovery" not in message for message in info_messages), info_messages
+
+
+def test_discover_files_routine_logs_are_debug_only(tmp_path: Path, caplog) -> None:
+    data_dir = tmp_path / "data"
+    _write_file(data_dir, "alpha.csv")
+    _write_file(data_dir, "beta.csv")
+
+    caplog.set_level(logging.DEBUG)
+
+    results = discover_files(
+        directory=str(data_dir),
+        pattern="*.csv",
+        recursive=False,
+    )
+
+    assert sorted(Path(result).name for result in results) == ["alpha.csv", "beta.csv"]
+
+    info_messages = [record.message for record in caplog.records if record.levelno == logging.INFO]
+    assert all("discover_files" not in message for message in info_messages), info_messages
+
+
+def test_discover_manifest_routine_logs_are_debug_only(tmp_path: Path, caplog) -> None:
+    base_dir = tmp_path / "major"
+    dataset_dir = base_dir / "dataset_a"
+    _write_file(dataset_dir, "result.csv")
+
+    config = {
+        "project": {
+            "directories": {"major_data_directory": str(base_dir)},
+            "file_extensions": ["csv"],
+        },
+        "datasets": {
+            "dataset_a": {
+                "patterns": ["*.csv"],
+            }
+        },
+        "experiments": {
+            "exp_a": {
+                "datasets": ["dataset_a"],
+            }
+        },
+    }
+
+    caplog.set_level(logging.DEBUG)
+
+    manifest = discover_experiment_manifest(
+        config=config,
+        experiment_name="exp_a",
+        parse_dates=False,
+        include_stats=False,
+        enable_kedro_metadata=False,
+        version_aware_patterns=False,
+    )
+
+    assert [Path(file_info.path).name for file_info in manifest.files] == ["result.csv"]
+
+    info_messages = [record.message for record in caplog.records if record.levelno == logging.INFO]
+    assert all("manifest" not in message.lower() for message in info_messages), info_messages


### PR DESCRIPTION
## Summary
- downgrade routine discovery success messages across discovery components to DEBUG so INFO stays focused on user milestones
- add regression tests verifying enumerator, discover_files, and manifest flows avoid emitting INFO logs during successful runs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d559e2c3f48320a146ec0452dd6899