### PR TITLE
refactor: remove legacy discovery pattern fallbacks

### DIFF
--- a/tests/flyrigloader/discovery/test_files.py
+++ b/tests/flyrigloader/discovery/test_files.py
@@ -264,9 +264,12 @@ class TestFileDiscoveryCore:
     # =========================================================================
 
     @pytest.mark.parametrize("extract_patterns,expected_metadata_keys", [
-        ([r".*/(mouse)_(\d{8})_(\w+)_(\d+)\.csv"], ["animal", "date", "condition", "replicate"]),
-        ([r".*/(\d{8})_(rat)_(\w+)_(\d+)\.csv"], ["date", "animal", "condition", "replicate"]),
-        ([r".*/(exp\d+)_(\w+)_(\w+)\.csv"], ["experiment_id", "animal", "condition"]),
+        ([r".*/(?P<animal>mouse)_(?P<date>\d{8})_(?P<condition>\w+)_(?P<replicate>\d+)\.csv"],
+         ["animal", "date", "condition", "replicate"]),
+        ([r".*/(?P<date>\d{8})_(?P<animal>rat)_(?P<condition>\w+)_(?P<replicate>\d+)\.csv"],
+         ["date", "animal", "condition", "replicate"]),
+        ([r".*/(?P<experiment_id>exp\d+)_(?P<animal>\w+)_(?P<condition>\w+)\.csv"],
+         ["experiment_id", "animal", "condition"]),
     ])
     def test_pattern_extraction_metadata(self, temp_filesystem, extract_patterns, expected_metadata_keys):
         """Test metadata extraction from filenames using regex patterns."""
@@ -673,7 +676,7 @@ class TestFileDiscoveryCore:
     def test_file_discoverer_class_integration(self, temp_filesystem, sample_files):
         """Test FileDiscoverer class with various configuration options."""
         # Test with extract patterns
-        patterns = [r".*/(mouse)_(\d{8})_(\w+)_(\d+)\.csv"]
+        patterns = [r".*/(?P<animal>mouse)_(?P<date>\d{8})_(?P<condition>\w+)_(?P<replicate>\d+)\.csv"]
         discoverer = FileDiscoverer(extract_patterns=patterns)
         
         # Create mouse file for pattern matching
@@ -709,7 +712,7 @@ class TestFileDiscoveryCore:
             
         # Configure discoverer with all options
         discoverer = FileDiscoverer(
-            extract_patterns=[r".*/(exp\d+)_(\w+)_(\d{8})\.csv"],
+            extract_patterns=[r".*/(?P<experiment_id>exp\d+)_(?P<animal>\w+)_(?P<date>\d{8})\.csv"],
             parse_dates=True,
             include_stats=True
         )

--- a/tests/flyrigloader/discovery/test_pattern_validation.py
+++ b/tests/flyrigloader/discovery/test_pattern_validation.py
@@ -1,0 +1,21 @@
+"""Focused tests for validating production-facing pattern behaviors."""
+
+import pytest
+
+from flyrigloader.discovery.patterns import PatternMatcher
+
+
+def test_patternmatcher_rejects_positional_groups():
+    """PatternMatcher should fail loudly when patterns use positional groups."""
+
+    positional_pattern = r".*_(\\d{8})_.*\\.csv"
+
+    matcher = PatternMatcher([positional_pattern])
+
+    import re
+
+    match_obj = re.search(r".*_(\d{8})_.*\.csv", "mouse_20240101_control.csv")
+    assert match_obj is not None, "Sanity check: positional pattern should still match"
+
+    with pytest.raises(ValueError):
+        matcher._extract_groups_from_match(match_obj, 0)


### PR DESCRIPTION
## Summary
- remove positional group fallbacks from the discovery pipeline and require named captures
- simplify `FileDiscoverer` configuration by dropping the legacy pattern conversion logic
- refresh discovery tests and add coverage ensuring positional-only patterns raise an error

## Testing
- pytest tests/flyrigloader/discovery/test_pattern_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68d59b34252c8320b26b7af97a42c335