### PR TITLE
feat: scope dependency provider overrides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ overview, and topical guides aligned with the evolving feature set.
 - **Embrace verbose logging** – call `initialize_logger()` during manual testing
   and ensure new code paths emit contextual `logger.info`/`logger.debug` messages
   rather than muting diagnostics.【F:src/flyrigloader/__init__.py†L122-L248】【F:src/flyrigloader/api/_core.py†L176-L213】
+- **Scope dependency overrides** – the dependency provider is a module-level
+  singleton. Use `use_dependency_provider()` when overriding in application code
+  and rely on the `dependency_provider_state_guard` pytest fixture to reset state
+  in tests so concurrent workflows remain isolated.【F:src/flyrigloader/api/dependencies.py†L300-L332】【F:tests/conftest.py†L120-L140】
 
 ## Documentation Alignment Checklist
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,9 +91,10 @@ providers:
 - **Loader & schema registries** – Register new loaders or validation schemas via
   `LoaderRegistry`/`SchemaRegistry`, including priority controls and capability
   queries for discovery-time diagnostics.【F:src/flyrigloader/registries/__init__.py†L1-L120】【F:src/flyrigloader/api/registry.py†L1-L98】
-- **Dependency provider overrides** – Use `set_dependency_provider()` during
-  testing or specialized deployments to swap discovery, IO, or utility
-  implementations without modifying the façade logic.【F:src/flyrigloader/api/dependencies.py†L1-L180】
+- **Dependency provider overrides** – Use `use_dependency_provider()` to scope
+  temporary overrides or `set_dependency_provider()` for longer-lived swaps
+  during specialized deployments. Both approaches reuse the same dependency
+  façade while keeping overrides explicit.【F:src/flyrigloader/api/dependencies.py†L300-L332】
 - **Configuration builders** – Compose validated configs programmatically through
   `create_config()` and helper functions, ensuring downstream modules always see
   typed models and consistent defaults.【F:src/flyrigloader/config/builder.py†L1-L120】

--- a/src/flyrigloader/api/__init__.py
+++ b/src/flyrigloader/api/__init__.py
@@ -47,6 +47,7 @@ from .dependencies import (
     get_dependency_provider,
     reset_dependency_provider,
     set_dependency_provider,
+    use_dependency_provider,
 )
 from .kedro import FlyRigLoaderDataSet, check_kedro_available, create_kedro_dataset
 from .manifest import discover_experiment_manifest, validate_manifest
@@ -86,6 +87,7 @@ __all__ = sorted(
         "read_pickle_any_format",
         "reset_dependency_provider",
         "set_dependency_provider",
+        "use_dependency_provider",
         "validate_manifest",
         "_create_test_dependency_provider",
         "_discover_experiment_manifest",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,6 +115,27 @@ except ModuleNotFoundError:  # pragma: no cover
     logger = _DummyLogger()
 
 
+@pytest.fixture(autouse=True)
+def dependency_provider_state_guard():
+    """Ensure dependency provider overrides never leak between tests."""
+
+    from flyrigloader.api import get_dependency_provider, reset_dependency_provider
+
+    reset_dependency_provider()
+    logger.debug(
+        "Dependency provider reset before test to %s",
+        type(get_dependency_provider()).__name__,
+    )
+    try:
+        yield
+    finally:
+        reset_dependency_provider()
+        logger.debug(
+            "Dependency provider reset after test to %s",
+            type(get_dependency_provider()).__name__,
+        )
+
+
 collect_ignore: List[str] = []
 
 if not HYPOTHESIS_AVAILABLE:

--- a/tests/flyrigloader/test_dependency_provider_isolation.py
+++ b/tests/flyrigloader/test_dependency_provider_isolation.py
@@ -1,0 +1,44 @@
+"""Tests for dependency provider isolation mechanisms."""
+
+from __future__ import annotations
+
+import pytest
+
+from flyrigloader.api import (
+    DefaultDependencyProvider,
+    get_dependency_provider,
+    set_dependency_provider,
+    use_dependency_provider,
+)
+
+
+class _MarkerDependencyProvider(DefaultDependencyProvider):
+    """Custom provider used to verify isolation semantics in tests."""
+
+
+@pytest.mark.usefixtures("dependency_provider_state_guard")
+def test_use_dependency_provider_scopes_override() -> None:
+    """Overrides within the context manager should not leak globally."""
+
+    original = get_dependency_provider()
+    override = _MarkerDependencyProvider()
+
+    with use_dependency_provider(override):
+        assert get_dependency_provider() is override
+
+    assert get_dependency_provider() is original
+
+
+def test_autouse_reset_fixture_prevents_leakage() -> None:
+    """An override in one test should not leak into another test."""
+
+    set_dependency_provider(_MarkerDependencyProvider())
+    assert isinstance(get_dependency_provider(), _MarkerDependencyProvider)
+
+
+def test_autouse_reset_fixture_runs_before_each_test() -> None:
+    """Subsequent tests should see the default dependency provider."""
+
+    provider = get_dependency_provider()
+    assert isinstance(provider, DefaultDependencyProvider)
+    assert not isinstance(provider, _MarkerDependencyProvider)


### PR DESCRIPTION
## Summary
- add a context manager to scope dependency provider overrides and restore state automatically
- provide an autouse pytest fixture to reset the dependency provider between tests and document the global singleton behavior
- expand documentation to highlight the new isolation workflow

## Testing
- pytest tests/flyrigloader/test_dependency_provider_isolation.py
- pytest tests/test_api_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d5a8c43f0c8320831ab2eaa83fcf2c