### PR TITLE
feat: allow abstract dependency providers

### DIFF
--- a/src/flyrigloader/api/__init__.py
+++ b/src/flyrigloader/api/__init__.py
@@ -43,6 +43,7 @@ from .config import (
     get_path_relative_to,
 )
 from .dependencies import (
+    AbstractDependencyProvider,
     DefaultDependencyProvider,
     get_dependency_provider,
     reset_dependency_provider,
@@ -58,6 +59,7 @@ __all__ = sorted(
     {
         "CONFIG_SOURCE_ERROR_MESSAGE",
         "MISSING_DATA_DIR_ERROR",
+        "AbstractDependencyProvider",
         "DefaultDependencyProvider",
         "FlyRigLoaderDataSet",
         "FlyRigLoaderError",


### PR DESCRIPTION
## Summary
- allow dependency provider overrides to accept any AbstractDependencyProvider implementation
- add thread-local override tracking and document the behavior
- cover protocol-only providers with dedicated tests

## Testing
- pytest tests/flyrigloader/test_dependency_provider_isolation.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d69fd2c3c0832087b3c3de486a5218